### PR TITLE
Integrate keymap-drawer into flake

### DIFF
--- a/config/keymap_drawer.yaml
+++ b/config/keymap_drawer.yaml
@@ -327,16 +327,16 @@ parse_config:
     KP_MULTIPLY: '*'
     KP_EQUAL: '='
     KP_DOT: '.'
-    KP_N1: 1
-    KP_N2: 2
-    KP_N3: 3
-    KP_N4: 4
-    KP_N5: 5
-    KP_N6: 6
-    KP_N7: 7
-    KP_N8: 8
-    KP_N9: 9
-    KP_N0: 0
+    KP_N1: '1'
+    KP_N2: '2'
+    KP_N3: '3'
+    KP_N4: '4'
+    KP_N5: '5'
+    KP_N6: '6'
+    KP_N7: '7'
+    KP_N8: '8'
+    KP_N9: '9'
+    KP_N0: '0'
 
     'LC(LEFT)': $$mdi:chevron-double-left$$
     'LC(RIGHT)': $$mdi:chevron-double-right$$

--- a/drawer/default.nix
+++ b/drawer/default.nix
@@ -72,9 +72,8 @@ with lib; {
         paths =
           concatMap (
             {
-              name,
               file,
-              data,
+              name,
               layers,
               ...
             }:
@@ -83,7 +82,7 @@ with lib; {
                   echo "Drawing all layers for ${name}"
                   mkdir -p "$out"
                   ${exe} --config "${configFile}" \
-                    draw ${file}" \
+                    draw "${file}" \
                     > "$out/${name}.svg"
                 '')
               ]

--- a/drawer/default.nix
+++ b/drawer/default.nix
@@ -60,9 +60,20 @@ with lib; {
           pkgs.runCommandNoCC "${name}-parsed" {} ''
             echo "Parsing keymap for ${name}"
             mkdir -p "$out"
+
+            # Create a temp link because keymap-drawer uses the file's stem
+            # to guess the keyboard name...
+            # Using `file` directly won't work because it has a nar hash prefix.
+            # FIXME find workaround upstream
+            LINK="$out/${baseNameOf file}"
+            ln -s "${file}" "$LINK"
+
             ${exe} --config "${configFile}" \
-              parse --zmk-keymap "${file}" \
+              parse --zmk-keymap "$LINK" \
               > "$out/${name}.yaml"
+
+            # Cleanup temp link
+            rm "$LINK"
           '')
         keymapFiles;
       };

--- a/drawer/default.nix
+++ b/drawer/default.nix
@@ -31,10 +31,10 @@ with lib; {
 
     # List of parsed keyboard configs, complete with various metadata
     parsedCfgs = mapAttrsToList (fname: type:
-      assert hasSuffix ".keymap" fname;
+      assert hasSuffix ".yaml" fname;
       assert type != "directory"; rec {
         file = parsedPkg + "/${fname}";
-        name = removeSuffix ".keymap" fname;
+        name = removeSuffix ".yaml" fname;
         data = importYaml file;
         layers = attrNames data.layers;
       }) (readDir parsedPkg);

--- a/drawer/default.nix
+++ b/drawer/default.nix
@@ -1,0 +1,24 @@
+{
+  inputs,
+  lib,
+  ...
+}: let
+in {
+    perSystem = {
+      pkgs,
+      system,
+      ...
+    }: let
+      inherit (inputs.poetry2nix.lib.mkPoetry2Nix {inherit pkgs;}) mkPoetryApplication;
+    in {
+      packages = {
+        keymap-drawer = mkPoetryApplication {
+          projectDir = inputs.keymap-drawer;
+          preferWheels = true;
+          meta = {
+            mainProgram = "keymap";
+            homepage = "https://github.com/caksoylar/keymap-drawer";
+          };
+        };
+    };
+}

--- a/drawer/default.nix
+++ b/drawer/default.nix
@@ -5,11 +5,14 @@
 }: let
 in {
     perSystem = {
+      config,
       pkgs,
       system,
       ...
     }: let
       inherit (inputs.poetry2nix.lib.mkPoetry2Nix {inherit pkgs;}) mkPoetryApplication;
+      pkg = config.packages.keymap-drawer;
+      exe = lib.getExe pkg;
     in {
       packages = {
         keymap-drawer = mkPoetryApplication {
@@ -20,5 +23,24 @@ in {
             homepage = "https://github.com/caksoylar/keymap-drawer";
           };
         };
+
+        keymap-drawer-configs = pkgs.runCommand "configs" {} ''
+          echo "writing config to $out"
+          mkdir -p $out
+
+          # TODO set generic vars in one place globally
+          CONFIG="${../config/keymap_drawer.yaml}"
+
+          # TODO consider running through `parallel`?
+          for KEYMAP in ${ ../config }/*.keymap; do
+            KEYBOARD=$(basename -s .keymap "$KEYMAP")
+            OUTPUT="$out"/"$KEYBOARD".yaml
+
+            echo "Parsing keymap for $KEYBOARD"
+            # ${exe} -c "$CONFIG" parse -z "$KEYMAP" > "$OUTPUT"
+            ${exe} parse -z "$KEYMAP" > "$OUTPUT"
+          done
+        '';
+      };
     };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -59,6 +59,24 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "glove80-zmk": {
       "flake": false,
       "locked": {
@@ -72,6 +90,43 @@
       "original": {
         "owner": "moergo-sc",
         "repo": "zmk",
+        "type": "github"
+      }
+    },
+    "keymap-drawer": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1711220101,
+        "narHash": "sha256-XY/52aNvwuIJCbCF8xkDUKI9LTntwbmhJFr6DS4Yb+0=",
+        "owner": "caksoylar",
+        "repo": "keymap-drawer",
+        "rev": "f63ccf49bae1df2f58d3f6bab8a0fc13faf6c981",
+        "type": "github"
+      },
+      "original": {
+        "owner": "caksoylar",
+        "repo": "keymap-drawer",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1703863825,
+        "narHash": "sha256-rXwqjtwiGKJheXB43ybM8NwWB8rO2dSRrEqes0S7F5Y=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "5163432afc817cf8bd1f031418d1869e4c9d5547",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
         "type": "github"
       }
     },
@@ -91,12 +146,38 @@
         "type": "github"
       }
     },
+    "poetry2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_3",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1708589824,
+        "narHash": "sha256-2GOiFTkvs5MtVF65sC78KNVxQSmsxtk0WmV1wJ9V2ck=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "3c92540611f42d3fb2d0d084a6c694cd6544b609",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "devshell": "devshell",
         "flake-parts": "flake-parts",
         "glove80-zmk": "glove80-zmk",
-        "nixpkgs": "nixpkgs"
+        "keymap-drawer": "keymap-drawer",
+        "nixpkgs": "nixpkgs",
+        "poetry2nix": "poetry2nix"
       }
     },
     "systems": {
@@ -111,6 +192,56 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "id": "systems",
+        "type": "indirect"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708335038,
+        "narHash": "sha256-ETLZNFBVCabo7lJrpjD6cAbnE11eDOjaQnznmg/6hAE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "e504621290a1fd896631ddbc5e9c16f4366c9f65",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
       systems = nixpkgs.lib.systems.flakeExposed;
       imports = [
         inputs.devshell.flakeModule
+        ./drawer
       ];
 
       perSystem = {
@@ -61,14 +62,6 @@
           };
         in
           firmware.combine_uf2 glove80_left glove80_right;
-
-        packages.keymap-drawer = let
-          inherit (poetry2nix.lib.mkPoetry2Nix {inherit pkgs;}) mkPoetryApplication;
-        in
-          mkPoetryApplication {
-            projectDir = keymap-drawer;
-            preferWheels = true;
-          };
 
         devshells.default.commands = [
           {

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,14 @@
       url = "github:moergo-sc/zmk";
       flake = false;
     };
+    keymap-drawer = {
+      url = "github:caksoylar/keymap-drawer";
+      flake = false;
+    };
+    poetry2nix = {
+      url = "github:nix-community/poetry2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";
@@ -19,6 +27,8 @@
     self,
     nixpkgs,
     glove80-zmk,
+    keymap-drawer,
+    poetry2nix,
     flake-parts,
     devshell,
   } @ inputs:
@@ -51,6 +61,14 @@
           };
         in
           firmware.combine_uf2 glove80_left glove80_right;
+
+        packages.keymap-drawer = let
+          inherit (poetry2nix.lib.mkPoetry2Nix {inherit pkgs;}) mkPoetryApplication;
+        in
+          mkPoetryApplication {
+            projectDir = keymap-drawer;
+            preferWheels = true;
+          };
 
         devshells.default.commands = [
           {

--- a/img/glove80.svg
+++ b/img/glove80.svg
@@ -1,4 +1,4 @@
-<svg width="1068" height="3130" viewBox="0 0 1068 3130" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1068" height="3183" viewBox="0 0 1068 3183" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <defs>/* start glyphs */
 <svg id="mdi:apple-keyboard-caps">
 <svg xmlns="http://www.w3.org/2000/svg" id="mdi-apple-keyboard-caps" viewBox="0 0 24 24"><path d="M15,14V8H17.17L12,2.83L6.83,8H9V14H15M12,0L22,10H17V16H7V10H2L12,0M7,18H17V24H7V18M15,20H9V22H15V20Z" /></svg>
@@ -116,6 +116,9 @@ svg.keymap {
 /* default key styling */
 rect.key {
     fill: #f6f8fa;
+}
+
+rect.key, rect.combo {
     stroke: #c9cccf;
     stroke-width: 1;
 }
@@ -300,8 +303,8 @@ text.hold {
     }
 }
 </style>
-<g transform="translate(30, 0)" class="layer-ColmakDH">
-<text x="0" y="28" class="label">ColmakDH</text>
+<g transform="translate(30, 0)" class="layer-default">
+<text x="0" y="28" class="label">default</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 56)" class="key keypos-0">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -521,30 +524,30 @@ text.hold {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">V</text>
 </g>
-<g transform="translate(367, 306) rotate(20.0)" class="key keypos-52">
+<g transform="translate(371, 312) rotate(30.0)" class="key keypos-52">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <use href="#mdi:apple-keyboard-shift" xlink:href="#mdi:apple-keyboard-shift" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:apple-keyboard-shift"/>
 </g>
-<g transform="translate(419, 329) rotate(30.0)" class="key info keypos-53">
+<g transform="translate(420, 350) rotate(45.0)" class="key info keypos-53">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
 <use href="#num-nav" xlink:href="#num-nav" x="-9" y="-7" height="14" width="18.666666666666668" class="key info tap glyph num-nav"/>
 <text x="0" y="24" class="key info hold"><tspan style="font-size: 71%">Num/Nav</tspan></text>
 </g>
-<g transform="translate(466, 365) rotate(45.0)" class="key info keypos-54">
+<g transform="translate(458, 399) rotate(60.0)" class="key info keypos-54">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
 <use href="#mdi:monitor-dashboard" xlink:href="#mdi:monitor-dashboard" x="-7" y="-7" height="14" width="14.0" class="key info tap glyph mdi:monitor-dashboard"/>
 <text x="0" y="24" class="key info hold">Meta</text>
 </g>
-<g transform="translate(546, 361) rotate(-45.0)" class="key keypos-55">
+<g transform="translate(550, 399) rotate(-60.0)" class="key keypos-55">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">Alt</text>
 </g>
-<g transform="translate(594, 327) rotate(-30.0)" class="key info keypos-56">
+<g transform="translate(588, 350) rotate(-45.0)" class="key info keypos-56">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
 <use href="#num-nav" xlink:href="#num-nav" x="-9" y="-7" height="14" width="18.666666666666668" class="key info tap glyph num-nav"/>
 <text x="0" y="24" class="key info hold"><tspan style="font-size: 71%">Num/Nav</tspan></text>
 </g>
-<g transform="translate(646, 304) rotate(-20.0)" class="key keypos-57">
+<g transform="translate(637, 312) rotate(-30.0)" class="key keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <use href="#mdi:apple-keyboard-shift" xlink:href="#mdi:apple-keyboard-shift" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:apple-keyboard-shift"/>
 </g>
@@ -593,31 +596,31 @@ text.hold {
 <g transform="translate(252, 308)" class="key keypos-68">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 </g>
-<g transform="translate(314, 356) rotate(15.0)" class="key keypos-69">
+<g transform="translate(314, 347) rotate(20.0)" class="key keypos-69">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <use href="#mdi:backspace" xlink:href="#mdi:backspace" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:backspace"/>
 </g>
-<g transform="translate(370, 379) rotate(25.0)" class="key keypos-70">
+<g transform="translate(369, 379) rotate(40.0)" class="key keypos-70">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">Esc</text>
-<text x="0" y="24" class="key hold"><tspan style="font-size: 71%">Symbols</tspan></text>
+<text x="0" y="24" class="key hold"><tspan style="font-size: 71%">symbols</tspan></text>
 </g>
-<g transform="translate(422, 417) rotate(45.0)" class="key keypos-71">
+<g transform="translate(410, 427) rotate(60.0)" class="key keypos-71">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <use href="#mdi:keyboard-tab-reverse" xlink:href="#mdi:keyboard-tab-reverse" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:keyboard-tab-reverse"/>
 <text x="0" y="24" class="key hold">Ctrl</text>
 </g>
-<g transform="translate(586, 417) rotate(-45.0)" class="key keypos-72">
+<g transform="translate(598, 427) rotate(-60.0)" class="key keypos-72">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <use href="#mdi:keyboard-tab" xlink:href="#mdi:keyboard-tab" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:keyboard-tab"/>
 <text x="0" y="24" class="key hold">Ctrl</text>
 </g>
-<g transform="translate(638, 379) rotate(-25.0)" class="key keypos-73">
+<g transform="translate(639, 379) rotate(-40.0)" class="key keypos-73">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <use href="#mdi:keyboard-return" xlink:href="#mdi:keyboard-return" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:keyboard-return"/>
-<text x="0" y="24" class="key hold"><tspan style="font-size: 71%">Symbols</tspan></text>
+<text x="0" y="24" class="key hold"><tspan style="font-size: 71%">symbols</tspan></text>
 </g>
-<g transform="translate(694, 356) rotate(-15.0)" class="key keypos-74">
+<g transform="translate(694, 347) rotate(-20.0)" class="key keypos-74">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <use href="#mdi:keyboard-space" xlink:href="#mdi:keyboard-space" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:keyboard-space"/>
 </g>
@@ -640,21 +643,21 @@ text.hold {
 <text x="0" y="24" class="key info hold"><tspan style="font-size: 83%">Qwerty</tspan></text>
 </g>
 <g class="combo combopos-0">
-<path d="M507,305 l-121,1" class="combo"/>
-<path d="M507,305 l121,-1" class="combo"/>
-<rect rx="6" ry="6" x="493" y="292" width="28" height="26" class="combo"/>
-<use href="#mdi:apple-keyboard-caps" xlink:href="#mdi:apple-keyboard-caps" x="500" y="298" height="14" width="14.0" class="combo tap glyph mdi:apple-keyboard-caps"/>
+<path d="M504,312 l-114,0" class="combo"/>
+<path d="M504,312 l114,0" class="combo"/>
+<rect rx="6" ry="6" x="490" y="299" width="28" height="26" class="combo"/>
+<use href="#mdi:apple-keyboard-caps" xlink:href="#mdi:apple-keyboard-caps" x="497" y="305" height="14" width="14.0" class="combo tap glyph mdi:apple-keyboard-caps"/>
 </g>
 <g class="combo combopos-1">
-<path d="M504,356 l-171,0" class="combo"/>
-<path d="M504,356 l171,0" class="combo"/>
-<rect rx="6" ry="6" x="490" y="343" width="28" height="26" class="combo"/>
-<text x="504" y="356" class="combo tap">_</text>
+<path d="M504,347 l-171,0" class="combo"/>
+<path d="M504,347 l171,0" class="combo"/>
+<rect rx="6" ry="6" x="490" y="334" width="28" height="26" class="combo"/>
+<text x="504" y="347" class="combo tap">_</text>
 </g>
 </g>
 </g>
-<g transform="translate(30, 512)" class="layer-Qwerty">
-<text x="0" y="28" class="label">Qwerty</text>
+<g transform="translate(30, 521)" class="layer-qwerty">
+<text x="0" y="28" class="label">qwerty</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 56)" class="key trans keypos-0">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
@@ -864,27 +867,27 @@ text.hold {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">B</text>
 </g>
-<g transform="translate(367, 306) rotate(20.0)" class="key trans keypos-52">
+<g transform="translate(371, 312) rotate(30.0)" class="key trans keypos-52">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(419, 329) rotate(30.0)" class="key trans keypos-53">
+<g transform="translate(420, 350) rotate(45.0)" class="key trans keypos-53">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(466, 365) rotate(45.0)" class="key trans keypos-54">
+<g transform="translate(458, 399) rotate(60.0)" class="key trans keypos-54">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(546, 361) rotate(-45.0)" class="key trans keypos-55">
+<g transform="translate(550, 399) rotate(-60.0)" class="key trans keypos-55">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(594, 327) rotate(-30.0)" class="key trans keypos-56">
+<g transform="translate(588, 350) rotate(-45.0)" class="key trans keypos-56">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(646, 304) rotate(-20.0)" class="key trans keypos-57">
+<g transform="translate(637, 312) rotate(-30.0)" class="key trans keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
@@ -932,27 +935,27 @@ text.hold {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(314, 356) rotate(15.0)" class="key trans keypos-69">
+<g transform="translate(314, 347) rotate(20.0)" class="key trans keypos-69">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(370, 379) rotate(25.0)" class="key trans keypos-70">
+<g transform="translate(369, 379) rotate(40.0)" class="key trans keypos-70">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(422, 417) rotate(45.0)" class="key trans keypos-71">
+<g transform="translate(410, 427) rotate(60.0)" class="key trans keypos-71">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(586, 417) rotate(-45.0)" class="key trans keypos-72">
+<g transform="translate(598, 427) rotate(-60.0)" class="key trans keypos-72">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(638, 379) rotate(-25.0)" class="key trans keypos-73">
+<g transform="translate(639, 379) rotate(-40.0)" class="key trans keypos-73">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(694, 356) rotate(-15.0)" class="key trans keypos-74">
+<g transform="translate(694, 347) rotate(-20.0)" class="key trans keypos-74">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
@@ -978,8 +981,8 @@ text.hold {
 </g>
 </g>
 </g>
-<g transform="translate(30, 1025)" class="layer-Symbols">
-<text x="0" y="28" class="label">Symbols</text>
+<g transform="translate(30, 1042)" class="layer-symbols">
+<text x="0" y="28" class="label">symbols</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 56)" class="key trans keypos-0">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
@@ -1189,25 +1192,25 @@ text.hold {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">€</text>
 </g>
-<g transform="translate(367, 306) rotate(20.0)" class="key trans keypos-52">
+<g transform="translate(371, 312) rotate(30.0)" class="key trans keypos-52">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(419, 329) rotate(30.0)" class="key keypos-53">
+<g transform="translate(420, 350) rotate(45.0)" class="key keypos-53">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 </g>
-<g transform="translate(466, 365) rotate(45.0)" class="key trans keypos-54">
+<g transform="translate(458, 399) rotate(60.0)" class="key trans keypos-54">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(546, 361) rotate(-45.0)" class="key trans keypos-55">
+<g transform="translate(550, 399) rotate(-60.0)" class="key trans keypos-55">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(594, 327) rotate(-30.0)" class="key keypos-56">
+<g transform="translate(588, 350) rotate(-45.0)" class="key keypos-56">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 </g>
-<g transform="translate(646, 304) rotate(-20.0)" class="key trans keypos-57">
+<g transform="translate(637, 312) rotate(-30.0)" class="key trans keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
@@ -1255,25 +1258,25 @@ text.hold {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(314, 356) rotate(15.0)" class="key trans keypos-69">
+<g transform="translate(314, 347) rotate(20.0)" class="key trans keypos-69">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(370, 379) rotate(25.0)" class="key held keypos-70">
+<g transform="translate(369, 379) rotate(40.0)" class="key held keypos-70">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key held"/>
 </g>
-<g transform="translate(422, 417) rotate(45.0)" class="key trans keypos-71">
+<g transform="translate(410, 427) rotate(60.0)" class="key trans keypos-71">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(586, 417) rotate(-45.0)" class="key trans keypos-72">
+<g transform="translate(598, 427) rotate(-60.0)" class="key trans keypos-72">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(638, 379) rotate(-25.0)" class="key held keypos-73">
+<g transform="translate(639, 379) rotate(-40.0)" class="key held keypos-73">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key held"/>
 </g>
-<g transform="translate(694, 356) rotate(-15.0)" class="key trans keypos-74">
+<g transform="translate(694, 347) rotate(-20.0)" class="key trans keypos-74">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
@@ -1299,8 +1302,8 @@ text.hold {
 </g>
 </g>
 </g>
-<g transform="translate(30, 1537)" class="layer-Navigation">
-<text x="0" y="28" class="label">Navigation</text>
+<g transform="translate(30, 1564)" class="layer-navigation">
+<text x="0" y="28" class="label">navigation</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 56)" class="key trans keypos-0">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
@@ -1526,29 +1529,29 @@ text.hold {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">/</text>
 </g>
-<g transform="translate(367, 306) rotate(20.0)" class="key trans keypos-52">
+<g transform="translate(371, 312) rotate(30.0)" class="key trans keypos-52">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(419, 329) rotate(30.0)" class="key info keypos-53">
+<g transform="translate(420, 350) rotate(45.0)" class="key info keypos-53">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
 <use href="#num-nav" xlink:href="#num-nav" x="-9" y="-7" height="14" width="18.666666666666668" class="key info tap glyph num-nav"/>
 <text x="0" y="24" class="key info hold"><tspan style="font-size: 71%">Num/Nav</tspan></text>
 </g>
-<g transform="translate(466, 365) rotate(45.0)" class="key trans keypos-54">
+<g transform="translate(458, 399) rotate(60.0)" class="key trans keypos-54">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(546, 361) rotate(-45.0)" class="key trans keypos-55">
+<g transform="translate(550, 399) rotate(-60.0)" class="key trans keypos-55">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(594, 327) rotate(-30.0)" class="key info keypos-56">
+<g transform="translate(588, 350) rotate(-45.0)" class="key info keypos-56">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
 <use href="#num-nav" xlink:href="#num-nav" x="-9" y="-7" height="14" width="18.666666666666668" class="key info tap glyph num-nav"/>
 <text x="0" y="24" class="key info hold"><tspan style="font-size: 71%">Num/Nav</tspan></text>
 </g>
-<g transform="translate(646, 304) rotate(-20.0)" class="key trans keypos-57">
+<g transform="translate(637, 312) rotate(-30.0)" class="key trans keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
@@ -1596,27 +1599,27 @@ text.hold {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">.</text>
 </g>
-<g transform="translate(314, 356) rotate(15.0)" class="key trans keypos-69">
+<g transform="translate(314, 347) rotate(20.0)" class="key trans keypos-69">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(370, 379) rotate(25.0)" class="key keypos-70">
+<g transform="translate(369, 379) rotate(40.0)" class="key keypos-70">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">Esc</text>
 </g>
-<g transform="translate(422, 417) rotate(45.0)" class="key trans keypos-71">
+<g transform="translate(410, 427) rotate(60.0)" class="key trans keypos-71">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(586, 417) rotate(-45.0)" class="key trans keypos-72">
+<g transform="translate(598, 427) rotate(-60.0)" class="key trans keypos-72">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(638, 379) rotate(-25.0)" class="key keypos-73">
+<g transform="translate(639, 379) rotate(-40.0)" class="key keypos-73">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <use href="#mdi:keyboard-return" xlink:href="#mdi:keyboard-return" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:keyboard-return"/>
 </g>
-<g transform="translate(694, 356) rotate(-15.0)" class="key trans keypos-74">
+<g transform="translate(694, 347) rotate(-20.0)" class="key trans keypos-74">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
@@ -1642,8 +1645,8 @@ text.hold {
 </g>
 </g>
 </g>
-<g transform="translate(30, 2050)" class="layer-Gaming">
-<text x="0" y="28" class="label">Gaming</text>
+<g transform="translate(30, 2085)" class="layer-gaming">
+<text x="0" y="28" class="label">gaming</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 56)" class="key trans keypos-0">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
@@ -1850,27 +1853,27 @@ text.hold {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">V</text>
 </g>
-<g transform="translate(367, 306) rotate(20.0)" class="key keypos-52">
+<g transform="translate(371, 312) rotate(30.0)" class="key keypos-52">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">T</text>
 </g>
-<g transform="translate(419, 329) rotate(30.0)" class="key keypos-53">
+<g transform="translate(420, 350) rotate(45.0)" class="key keypos-53">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">G</text>
 </g>
-<g transform="translate(466, 365) rotate(45.0)" class="key keypos-54">
+<g transform="translate(458, 399) rotate(60.0)" class="key keypos-54">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">B</text>
 </g>
-<g transform="translate(546, 361) rotate(-45.0)" class="key trans keypos-55">
+<g transform="translate(550, 399) rotate(-60.0)" class="key trans keypos-55">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(594, 327) rotate(-30.0)" class="key trans keypos-56">
+<g transform="translate(588, 350) rotate(-45.0)" class="key trans keypos-56">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(646, 304) rotate(-20.0)" class="key trans keypos-57">
+<g transform="translate(637, 312) rotate(-30.0)" class="key trans keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
@@ -1916,27 +1919,27 @@ text.hold {
 <g transform="translate(252, 308)" class="key keypos-68">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 </g>
-<g transform="translate(314, 356) rotate(15.0)" class="key keypos-69">
+<g transform="translate(314, 347) rotate(20.0)" class="key keypos-69">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <use href="#mdi:keyboard-space" xlink:href="#mdi:keyboard-space" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:keyboard-space"/>
 </g>
-<g transform="translate(370, 379) rotate(25.0)" class="key keypos-70">
+<g transform="translate(369, 379) rotate(40.0)" class="key keypos-70">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">Esc</text>
 </g>
-<g transform="translate(422, 417) rotate(45.0)" class="key keypos-71">
+<g transform="translate(410, 427) rotate(60.0)" class="key keypos-71">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">`</text>
 </g>
-<g transform="translate(586, 417) rotate(-45.0)" class="key trans keypos-72">
+<g transform="translate(598, 427) rotate(-60.0)" class="key trans keypos-72">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(638, 379) rotate(-25.0)" class="key trans keypos-73">
+<g transform="translate(639, 379) rotate(-40.0)" class="key trans keypos-73">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
-<g transform="translate(694, 356) rotate(-15.0)" class="key trans keypos-74">
+<g transform="translate(694, 347) rotate(-20.0)" class="key trans keypos-74">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
 </g>
@@ -1962,8 +1965,8 @@ text.hold {
 </g>
 </g>
 </g>
-<g transform="translate(30, 2562)" class="layer-Magic">
-<text x="0" y="28" class="label">Magic</text>
+<g transform="translate(30, 2606)" class="layer-magic">
+<text x="0" y="28" class="label">magic</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 56)" class="key info keypos-0">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
@@ -2158,26 +2161,26 @@ text.hold {
 <g transform="translate(308, 252)" class="key keypos-51">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 </g>
-<g transform="translate(367, 306) rotate(20.0)" class="key info keypos-52">
+<g transform="translate(371, 312) rotate(30.0)" class="key info keypos-52">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
 <use href="#mdi:bluetooth" xlink:href="#mdi:bluetooth" x="-7" y="-7" height="14" width="14.0" class="key info tap glyph mdi:bluetooth"/>
 <text x="0" y="-24" class="key info shifted">2</text>
 </g>
-<g transform="translate(419, 329) rotate(30.0)" class="key info keypos-53">
+<g transform="translate(420, 350) rotate(45.0)" class="key info keypos-53">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
 <use href="#mdi:bluetooth" xlink:href="#mdi:bluetooth" x="-7" y="-7" height="14" width="14.0" class="key info tap glyph mdi:bluetooth"/>
 <text x="0" y="-24" class="key info shifted">3</text>
 </g>
-<g transform="translate(466, 365) rotate(45.0)" class="key keypos-54">
+<g transform="translate(458, 399) rotate(60.0)" class="key keypos-54">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 </g>
-<g transform="translate(546, 361) rotate(-45.0)" class="key keypos-55">
+<g transform="translate(550, 399) rotate(-60.0)" class="key keypos-55">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 </g>
-<g transform="translate(594, 327) rotate(-30.0)" class="key keypos-56">
+<g transform="translate(588, 350) rotate(-45.0)" class="key keypos-56">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 </g>
-<g transform="translate(646, 304) rotate(-20.0)" class="key keypos-57">
+<g transform="translate(637, 312) rotate(-30.0)" class="key keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 </g>
 <g transform="translate(700, 252)" class="key keypos-58">
@@ -2214,27 +2217,27 @@ text.hold {
 <g transform="translate(252, 308)" class="key keypos-68">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 </g>
-<g transform="translate(314, 356) rotate(15.0)" class="key info keypos-69">
+<g transform="translate(314, 347) rotate(20.0)" class="key info keypos-69">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
 <use href="#mdi:bluetooth" xlink:href="#mdi:bluetooth" x="-7" y="-7" height="14" width="14.0" class="key info tap glyph mdi:bluetooth"/>
 <text x="0" y="-24" class="key info shifted">0</text>
 </g>
-<g transform="translate(370, 379) rotate(25.0)" class="key info keypos-70">
+<g transform="translate(369, 379) rotate(40.0)" class="key info keypos-70">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
 <use href="#mdi:bluetooth" xlink:href="#mdi:bluetooth" x="-7" y="-7" height="14" width="14.0" class="key info tap glyph mdi:bluetooth"/>
 <text x="0" y="-24" class="key info shifted">1</text>
 </g>
-<g transform="translate(422, 417) rotate(45.0)" class="key keypos-71">
+<g transform="translate(410, 427) rotate(60.0)" class="key keypos-71">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <use href="#mdi:usb" xlink:href="#mdi:usb" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:usb"/>
 </g>
-<g transform="translate(586, 417) rotate(-45.0)" class="key keypos-72">
+<g transform="translate(598, 427) rotate(-60.0)" class="key keypos-72">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 </g>
-<g transform="translate(638, 379) rotate(-25.0)" class="key keypos-73">
+<g transform="translate(639, 379) rotate(-40.0)" class="key keypos-73">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 </g>
-<g transform="translate(694, 356) rotate(-15.0)" class="key keypos-74">
+<g transform="translate(694, 347) rotate(-20.0)" class="key keypos-74">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 </g>
 <g transform="translate(756, 308)" class="key keypos-75">

--- a/img/glove80.yaml
+++ b/img/glove80.yaml
@@ -1,6 +1,6 @@
 layout: {qmk_keyboard: glove80}
 layers:
-  ColmakDH:
+  default:
   - F1
   - F2
   - F3
@@ -71,17 +71,17 @@ layers:
   - ''
   - ''
   - $$mdi:backspace$$
-  - {t: Esc, h: Symbols}
+  - {t: Esc, h: symbols}
   - {t: '$$mdi:keyboard-tab-reverse$$', h: Ctrl}
   - {t: '$$mdi:keyboard-tab$$', h: Ctrl}
-  - {t: '$$mdi:keyboard-return$$', h: Symbols}
+  - {t: '$$mdi:keyboard-return$$', h: symbols}
   - $$mdi:keyboard-space$$
   - ''
   - ''
   - ''
   - AltGr
   - {t: '$$mdi:keyboard-outline$$', h: Qwerty, type: info}
-  Qwerty:
+  qwerty:
   - {t: '$$mdi:chevron-down$$', type: trans}
   - {t: '$$mdi:chevron-down$$', type: trans}
   - {t: '$$mdi:chevron-down$$', type: trans}
@@ -162,7 +162,7 @@ layers:
   - {t: '$$mdi:chevron-down$$', type: trans}
   - {t: '$$mdi:chevron-down$$', type: trans}
   - {t: '$$mdi:chevron-down$$', type: trans}
-  Symbols:
+  symbols:
   - {t: '$$mdi:chevron-down$$', type: trans}
   - {t: '$$mdi:chevron-down$$', type: trans}
   - {t: '$$mdi:chevron-down$$', type: trans}
@@ -243,7 +243,7 @@ layers:
   - {t: '$$mdi:chevron-down$$', type: trans}
   - {t: '$$mdi:chevron-down$$', type: trans}
   - {t: '$$mdi:chevron-down$$', type: trans}
-  Navigation:
+  navigation:
   - {t: '$$mdi:chevron-down$$', type: trans}
   - {t: '$$mdi:chevron-down$$', type: trans}
   - {t: '$$mdi:chevron-down$$', type: trans}
@@ -324,7 +324,7 @@ layers:
   - $$mdi:skip-next$$
   - {t: '$$mdi:chevron-down$$', type: trans}
   - {t: '$$mdi:chevron-down$$', type: trans}
-  Gaming:
+  gaming:
   - {t: '$$mdi:chevron-down$$', type: trans}
   - {t: '$$mdi:chevron-down$$', type: trans}
   - {t: '$$mdi:chevron-down$$', type: trans}
@@ -405,7 +405,7 @@ layers:
   - {t: '$$mdi:chevron-down$$', type: trans}
   - {t: '$$mdi:chevron-down$$', type: trans}
   - {t: '$$mdi:chevron-down$$', type: trans}
-  Magic:
+  magic:
   - {t: '$$mdi:bluetooth-off$$', h: Clear, type: info}
   - ''
   - ''
@@ -489,7 +489,7 @@ layers:
 combos:
 - p: [52, 57]
   k: $$mdi:apple-keyboard-caps$$
-  l: [ColmakDH]
+  l: [default]
 - p: [69, 74]
   k: _
-  l: [ColmakDH]
+  l: [default]

--- a/img/glove80_default.svg
+++ b/img/glove80_default.svg
@@ -1,0 +1,659 @@
+<svg width="1068" height="577" viewBox="0 0 1068 577" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>/* start glyphs */
+<svg id="mdi:apple-keyboard-caps">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-apple-keyboard-caps" viewBox="0 0 24 24"><path d="M15,14V8H17.17L12,2.83L6.83,8H9V14H15M12,0L22,10H17V16H7V10H2L12,0M7,18H17V24H7V18M15,20H9V22H15V20Z" /></svg>
+</svg>
+<svg id="mdi:apple-keyboard-shift">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-apple-keyboard-shift" viewBox="0 0 24 24"><path d="M15,18V12H17.17L12,6.83L6.83,12H9V18H15M12,4L22,14H17V20H7V14H2L12,4Z" /></svg>
+</svg>
+<svg id="mdi:arrow-down-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-down-bold" viewBox="0 0 24 24"><path d="M9,4H15V12H19.84L12,19.84L4.16,12H9V4Z" /></svg>
+</svg>
+<svg id="mdi:arrow-left-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-left-bold" viewBox="0 0 24 24"><path d="M20,9V15H12V19.84L4.16,12L12,4.16V9H20Z" /></svg>
+</svg>
+<svg id="mdi:arrow-right-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-right-bold" viewBox="0 0 24 24"><path d="M4,15V9H12V4.16L19.84,12L12,19.84V15H4Z" /></svg>
+</svg>
+<svg id="mdi:arrow-up-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-up-bold" viewBox="0 0 24 24"><path d="M15,20H9V12H4.16L12,4.16L19.84,12H15V20Z" /></svg>
+</svg>
+<svg id="mdi:backspace">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-backspace" viewBox="0 0 24 24"><path d="M22,3H7C6.31,3 5.77,3.35 5.41,3.88L0,12L5.41,20.11C5.77,20.64 6.31,21 7,21H22A2,2 0 0,0 24,19V5A2,2 0 0,0 22,3M19,15.59L17.59,17L14,13.41L10.41,17L9,15.59L12.59,12L9,8.41L10.41,7L14,10.59L17.59,7L19,8.41L15.41,12" /></svg>
+</svg>
+<svg id="mdi:backspace-reverse-outline">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-backspace-reverse-outline" viewBox="0 0 24 24"><path d="M5,15.59L6.41,17L10,13.41L13.59,17L15,15.59L11.41,12L15,8.41L13.59,7L10,10.59L6.41,7L5,8.41L8.59,12L5,15.59M2,3A2,2 0 0,0 0,5V19A2,2 0 0,0 2,21H17C17.69,21 18.23,20.64 18.59,20.11L24,12L18.59,3.88C18.23,3.35 17.69,3 17,3H2M2,5H17L21.72,12L17,19H2V5Z" /></svg>
+</svg>
+<svg id="mdi:bluetooth">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-bluetooth" viewBox="0 0 24 24"><path d="M14.88,16.29L13,18.17V14.41M13,5.83L14.88,7.71L13,9.58M17.71,7.71L12,2H11V9.58L6.41,5L5,6.41L10.59,12L5,17.58L6.41,19L11,14.41V22H12L17.71,16.29L13.41,12L17.71,7.71Z" /></svg>
+</svg>
+<svg id="mdi:bluetooth-off">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-bluetooth-off" viewBox="0 0 24 24"><path d="M13,5.83L14.88,7.71L13.28,9.31L14.69,10.72L17.71,7.7L12,2H11V7.03L13,9.03M5.41,4L4,5.41L10.59,12L5,17.59L6.41,19L11,14.41V22H12L16.29,17.71L18.59,20L20,18.59M13,18.17V14.41L14.88,16.29" /></svg>
+</svg>
+<svg id="mdi:chevron-double-left">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-chevron-double-left" viewBox="0 0 24 24"><path d="M18.41,7.41L17,6L11,12L17,18L18.41,16.59L13.83,12L18.41,7.41M12.41,7.41L11,6L5,12L11,18L12.41,16.59L7.83,12L12.41,7.41Z" /></svg>
+</svg>
+<svg id="mdi:chevron-double-right">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-chevron-double-right" viewBox="0 0 24 24"><path d="M5.59,7.41L7,6L13,12L7,18L5.59,16.59L10.17,12L5.59,7.41M11.59,7.41L13,6L19,12L13,18L11.59,16.59L16.17,12L11.59,7.41Z" /></svg>
+</svg>
+<svg id="mdi:chevron-down">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-chevron-down" viewBox="0 0 24 24"><path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" /></svg>
+</svg>
+<svg id="mdi:controller">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-controller" viewBox="0 0 24 24"><path d="M7.97,16L5,19C4.67,19.3 4.23,19.5 3.75,19.5A1.75,1.75 0 0,1 2,17.75V17.5L3,10.12C3.21,7.81 5.14,6 7.5,6H16.5C18.86,6 20.79,7.81 21,10.12L22,17.5V17.75A1.75,1.75 0 0,1 20.25,19.5C19.77,19.5 19.33,19.3 19,19L16.03,16H7.97M7,8V10H5V11H7V13H8V11H10V10H8V8H7M16.5,8A0.75,0.75 0 0,0 15.75,8.75A0.75,0.75 0 0,0 16.5,9.5A0.75,0.75 0 0,0 17.25,8.75A0.75,0.75 0 0,0 16.5,8M14.75,9.75A0.75,0.75 0 0,0 14,10.5A0.75,0.75 0 0,0 14.75,11.25A0.75,0.75 0 0,0 15.5,10.5A0.75,0.75 0 0,0 14.75,9.75M18.25,9.75A0.75,0.75 0 0,0 17.5,10.5A0.75,0.75 0 0,0 18.25,11.25A0.75,0.75 0 0,0 19,10.5A0.75,0.75 0 0,0 18.25,9.75M16.5,11.5A0.75,0.75 0 0,0 15.75,12.25A0.75,0.75 0 0,0 16.5,13A0.75,0.75 0 0,0 17.25,12.25A0.75,0.75 0 0,0 16.5,11.5Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-outline">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-outline" viewBox="0 0 24 24"><path d="M4,5A2,2 0 0,0 2,7V17A2,2 0 0,0 4,19H20A2,2 0 0,0 22,17V7A2,2 0 0,0 20,5H4M4,7H20V17H4V7M5,8V10H7V8H5M8,8V10H10V8H8M11,8V10H13V8H11M14,8V10H16V8H14M17,8V10H19V8H17M5,11V13H7V11H5M8,11V13H10V11H8M11,11V13H13V11H11M14,11V13H16V11H14M17,11V13H19V11H17M8,14V16H16V14H8Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-return">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-return" viewBox="0 0 24 24"><path d="M19,7V11H5.83L9.41,7.41L8,6L2,12L8,18L9.41,16.58L5.83,13H21V7H19Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-space">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-space" viewBox="0 0 24 24"><path d="M3 15H5V19H19V15H21V19C21 20.1 20.1 21 19 21H5C3.9 21 3 20.1 3 19V15Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-tab">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-tab" viewBox="0 0 24 24"><path d="M20,18H22V6H20M11.59,7.41L15.17,11H1V13H15.17L11.59,16.58L13,18L19,12L13,6L11.59,7.41Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-tab-reverse">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-tab-reverse" viewBox="0 0 24 24"><path d="M4 6H2V18H4M11 6L5 12L11 18L12.41 16.58L8.83 13H23V11H8.83L12.41 7.41L11 6Z" /></svg>
+</svg>
+<svg id="mdi:monitor-dashboard">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-monitor-dashboard" viewBox="0 0 24 24"><path d="M21,16V4H3V16H21M21,2A2,2 0 0,1 23,4V16A2,2 0 0,1 21,18H14V20H16V22H8V20H10V18H3C1.89,18 1,17.1 1,16V4C1,2.89 1.89,2 3,2H21M5,6H14V11H5V6M15,6H19V8H15V6M19,9V14H15V9H19M5,12H9V14H5V12M10,12H14V14H10V12Z" /></svg>
+</svg>
+<svg id="mdi:play-pause">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-play-pause" viewBox="0 0 24 24"><path d="M3,5V19L11,12M13,19H16V5H13M18,5V19H21V5" /></svg>
+</svg>
+<svg id="mdi:skip-next">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-skip-next" viewBox="0 0 24 24"><path d="M16,18H18V6H16M6,18L14.5,12L6,6V18Z" /></svg>
+</svg>
+<svg id="mdi:skip-previous">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-skip-previous" viewBox="0 0 24 24"><path d="M6,18V6H8V18H6M9.5,12L18,6V18L9.5,12Z" /></svg>
+</svg>
+<svg id="mdi:usb">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-usb" viewBox="0 0 24 24"><path d="M15,7V11H16V13H13V5H15L12,1L9,5H11V13H8V10.93C8.7,10.56 9.2,9.85 9.2,9C9.2,7.78 8.21,6.8 7,6.8C5.78,6.8 4.8,7.78 4.8,9C4.8,9.85 5.3,10.56 6,10.93V13A2,2 0 0,0 8,15H11V18.05C10.29,18.41 9.8,19.15 9.8,20A2.2,2.2 0 0,0 12,22.2A2.2,2.2 0 0,0 14.2,20C14.2,19.15 13.71,18.41 13,18.05V15H16A2,2 0 0,0 18,13V11H19V7H15Z" /></svg>
+</svg>
+<svg id="mdi:volume-high">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-volume-high" viewBox="0 0 24 24"><path d="M14,3.23V5.29C16.89,6.15 19,8.83 19,12C19,15.17 16.89,17.84 14,18.7V20.77C18,19.86 21,16.28 21,12C21,7.72 18,4.14 14,3.23M16.5,12C16.5,10.23 15.5,8.71 14,7.97V16C15.5,15.29 16.5,13.76 16.5,12M3,9V15H7L12,20V4L7,9H3Z" /></svg>
+</svg>
+<svg id="mdi:volume-low">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-volume-low" viewBox="0 0 24 24"><path d="M7,9V15H11L16,20V4L11,9H7Z" /></svg>
+</svg>
+<svg id="mdi:volume-off">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-volume-off" viewBox="0 0 24 24"><path d="M12,4L9.91,6.09L12,8.18M4.27,3L3,4.27L7.73,9H3V15H7L12,20V13.27L16.25,17.53C15.58,18.04 14.83,18.46 14,18.7V20.77C15.38,20.45 16.63,19.82 17.68,18.96L19.73,21L21,19.73L12,10.73M19,12C19,12.94 18.8,13.82 18.46,14.64L19.97,16.15C20.62,14.91 21,13.5 21,12C21,7.72 18,4.14 14,3.23V5.29C16.89,6.15 19,8.83 19,12M16.5,12C16.5,10.23 15.5,8.71 14,7.97V10.18L16.45,12.63C16.5,12.43 16.5,12.21 16.5,12Z" /></svg>
+</svg>
+<svg id="moergo">
+<svg xml:space="preserve" viewBox="0 0 512 172">
+<path d="m60.09 80.108-.073-4.3-2.778-.046a288.998 288.998 0 0 1-3.245-.066l-.466-.02.07-9.061.07-9.062 1.777-.871c.978-.479 2.75-1.116 3.936-1.416l2.158-.546 1.938.098 1.937.098.741.549c.959.71 1.857 2.04 2.192 3.247l.266.957.002 12.37.001 12.369h18.786V75.94l-2.977-.004-2.976-.004-.335-.212-.334-.212.07-8.97.07-8.97 1.058-.598c.582-.329 1.951-.91 3.043-1.29l1.984-.691 2.513-.128 2.514-.127 1.188.615 1.189.615.578.87c.317.478.705 1.466.862 2.196l.284 1.326v24.052h18.785v-8.45l-3.24-.075-3.242-.074-.163-10.451-.163-10.451-.412-1.755c-.227-.965-.712-2.347-1.08-3.07l-.666-1.317-1.367-1.23-1.367-1.228-1.227-.55c-.676-.303-2.002-.717-2.948-.921l-1.72-.37-2.249-.004c-5.224-.006-8.928 1.154-15.272 4.78l-1.118.638-.767-.926c-.421-.51-1.437-1.388-2.257-1.952l-1.491-1.026-1.784-.654-1.784-.654-2.679-.142-2.678-.143-1.82.334c-2.344.43-5.837 1.628-7.714 2.644-.811.44-1.633.8-1.825.8h-.35v-3.176H34.749v8.731h6.62l-.068 11.012-.07 11.011-3.24-.045-3.242-.045v8.759h25.414zm307.77 35.396v-4.359l-3.903-.073-3.902-.073.035-4.101.035-4.101.462-1.853c.255-1.018.814-2.551 1.243-3.406l.78-1.555 1.203-1.287 1.203-1.286 1.393-.682 1.394-.681 2.079-.37c1.143-.205 2.766-.376 3.605-.38l1.527-.01-.071-5.754-.072-5.755-1.984.057c-2.584.073-4.265.478-6.216 1.496l-1.586.828-1.752 1.72-1.751 1.72-1.028 2.175-1.028 2.176-.331.007-.33.007V80.44h-17.994v8.466h6.88v22.225h-7.408v4.189c0 2.304.08 4.269.177 4.366l.176.176h27.164zm90.354-36.19-2.91.152-2.91.152-1.978.56c-1.087.308-2.884 1.032-3.992 1.609l-2.015 1.048-1.74 1.435-1.74 1.435-1.213 1.7c-2.198 3.08-3.398 6.55-3.74 10.81l-.178 2.2.3 2.459.301 2.459.63 1.98.628 1.98 1.085 1.827 1.085 1.826 1.653 1.634c4.082 4.035 8.828 5.94 15.046 6.043l2.016.033 2.327-.406 2.327-.406 1.743-.69c.959-.38 2.576-1.226 3.595-1.879l1.852-1.187 1.772-1.802 1.773-1.801 1.18-2.463 1.181-2.463.471-1.852.472-1.852.008-3.704.008-3.705-.35-1.587c-.52-2.36-1.549-4.81-2.85-6.788l-1.16-1.76-1.59-1.473c-2.927-2.71-6.842-4.546-11.12-5.216zm-3.213 9.327h3.301l1.28.546a8.732 8.732 0 0 1 .803.395 7.563 7.563 0 0 1 .96.64 6.99 6.99 0 0 1 1.385 1.453 7.746 7.746 0 0 1 .482.76 8.846 8.846 0 0 1 .419.847 10.375 10.375 0 0 1 .356.937 12.694 12.694 0 0 1 .297 1.029 16.376 16.376 0 0 1 .24 1.126 20.138 20.138 0 0 1 .181 1.224l.278 2.288-.27 2.375a31.867 31.867 0 0 1-.136 1.031 21.21 21.21 0 0 1-.162.925 15.296 15.296 0 0 1-.193.834 11.573 11.573 0 0 1-.23.76 9.573 9.573 0 0 1-.429 1.032 8.657 8.657 0 0 1-.542.952 10.276 10.276 0 0 1-.433.616l-.95 1.255-1.447.73-1.448.73-1.455.119a9.456 9.456 0 0 1-.638.03c-.11.002-.222.002-.332.002a11.503 11.503 0 0 1-.937-.045 5.823 5.823 0 0 1-.258-.03 3.177 3.177 0 0 1-.215-.039h-.001a8.305 8.305 0 0 1-1.082-.314 7.362 7.362 0 0 1-.746-.327 6.734 6.734 0 0 1-1.526-1.076 6.94 6.94 0 0 1-.74-.815 7.83 7.83 0 0 1-.494-.709 9.102 9.102 0 0 1-.443-.793 10.732 10.732 0 0 1-.392-.88 13.103 13.103 0 0 1-.343-.966 15.588 15.588 0 0 1-.202-.692l-.41-1.53.004-2.91.003-2.91.273-1.42a11.718 11.718 0 0 1 .274-1.062 18.563 18.563 0 0 1 .707-1.932l.706-1.573 1.046-.895 1.045-.895 1.207-.411zM132.263 11.697c-.034.046-2.106 11.691-4.604 25.88-2.498 14.188-5.55 31.51-6.78 38.493l-2.236 12.697.188.168c.104.093 14.892 2.745 32.864 5.894l32.676 5.726 2.514.825c1.382.453 3.96 1.517 5.727 2.363l3.214 1.539 2.607 1.766c5.134 3.477 9.088 7.32 12.861 12.496l1.6 2.196.291-.117c.16-.064 5.886-3.578 12.726-7.809 6.84-4.23 13.297-8.202 14.35-8.826 1.054-.623 1.917-1.227 1.919-1.342.006-.405-3.296-5.123-5.728-8.184l-2.463-3.1-3.378-3.386c-6.352-6.369-13.625-11.71-21.146-15.528-1.333-.677-2.54-1.375-2.685-1.552l-.261-.32 3.932-22.225c2.163-12.224 3.937-22.464 3.942-22.755l.008-.529-3.373-.595c-3.298-.583-37.653-6.632-64.983-11.443-7.545-1.328-13.747-2.378-13.782-2.332Zm36.233 30.314 2.35.444a24.764 24.764 0 0 1 2.44.592 23.266 23.266 0 0 1 2.777 1.03 22.678 22.678 0 0 1 2.19 1.123l1.554.907 1.945 1.848 1.945 1.848 1.024 1.626a20.183 20.183 0 0 1 .697 1.224 29.839 29.839 0 0 1 .695 1.405 21.308 21.308 0 0 1 .367.846l.737 1.85.392 2.251.391 2.252-.133 3.704-.133 3.704-.574 1.977a12.6 12.6 0 0 1-.137.439 19.653 19.653 0 0 1-.364 1.012 30.436 30.436 0 0 1-.905 2.107c-.076.158-.151.308-.224.448l-1.055 2.028-1.468 1.623a23.44 23.44 0 0 1-1.64 1.64 22.31 22.31 0 0 1-2.387 1.874 21.434 21.434 0 0 1-3.978 2.124 21.751 21.751 0 0 1-2.154.743l-1.97.568-3.837.108-3.836.108-2.25-.5a24.587 24.587 0 0 1-2.104-.565 23.215 23.215 0 0 1-1.993-.737 22.27 22.27 0 0 1-2.473-1.238 21.003 21.003 0 0 1-2.243-1.512 20.136 20.136 0 0 1-2.452-2.253 19.478 19.478 0 0 1-4.082-6.862 20.427 20.427 0 0 1-.215-.655l-.541-1.755-.293-2.61-.293-2.61.16-2.116a28.936 28.936 0 0 1 .326-2.643 25.64 25.64 0 0 1 .56-2.485 22.955 22.955 0 0 1 .793-2.32 20.977 20.977 0 0 1 .654-1.452 19.989 19.989 0 0 1 1.166-2.032 19.022 19.022 0 0 1 1.893-2.424 18.685 18.685 0 0 1 2.268-2.086 19.407 19.407 0 0 1 1.94-1.334 20.624 20.624 0 0 1 2.14-1.13 22.523 22.523 0 0 1 2.333-.917c.27-.09.544-.176.82-.257l2.298-.68 3.44-.14zm.595 31.233 1.124-.524.866-1.012.866-1.012.458-1.28c.252-.704.584-2.287.738-3.518l.278-2.238-.18-1.73c-.1-.953-.402-2.45-.67-3.33l-.49-1.599-.96-1.122-.962-1.123-1.029-.525c-.566-.288-1.554-.597-2.195-.684l-1.166-.16-1.387.332-1.387.333-1.039.939c-1.296 1.171-1.992 2.515-2.47 4.773l-.373 1.757-.005 2.147c-.002 1.18.114 2.788.258 3.572l.262 1.425.862 1.709.863 1.709 1.058.741 1.058.742 1.19.228a7.103 7.103 0 0 0 4.432-.55zm232.503 6.57-2.513.004-2.514.004-1.587.465c-.873.256-2.382.88-3.352 1.388l-1.765.924-1.686 1.632c-2.91 2.818-4.732 6.224-5.647 10.554l-.406 1.927v6.614l.393 1.866c1.764 8.345 7.056 13.98 14.045 14.951l1.93.269 1.799-.288 1.8-.287 1.868-.78 1.869-.779 2.313-1.738 2.314-1.737.3.186.303.186-.182 3.099c-.418 7.15-2.43 9.735-8.29 10.646l-1.955.304-2.253-.326-2.254-.326-1.762-.663c-.97-.365-2.146-.89-2.614-1.166l-.85-.501-2.436 3.359c-1.34 1.847-2.68 3.633-2.979 3.968l-.544.61.39.269c.215.148 1.224.677 2.244 1.176l1.855.905 2.575.654c4.317 1.095 9.784 1.447 14.354.924v-.001c3.285-.376 5.177-.9 7.805-2.159l2.249-1.077 1.765-1.792 1.764-1.793.937-1.947c.516-1.072 1.2-2.957 1.52-4.19l.584-2.244.109-16.999.109-17h6.573V80.44h-18.785v4.498h-.381c-.21 0-.987-.58-1.726-1.29l-1.346-1.289-1.575-.84c-.867-.462-2.204-1.034-2.97-1.272zm1.147 9.62h1.273l1.222.418 1.224.416 1.195 1.053 1.196 1.052.806 1.64.805 1.64.297 2.304.296 2.304-.306 2.053-.305 2.053-.624 1.363a6.734 6.734 0 0 1-.145.295 9.744 9.744 0 0 1-.364.643 13.175 13.175 0 0 1-.638.95 8.675 8.675 0 0 1-.212.275c-.07.085-.136.164-.2.235l-.936 1.036-1.26.63-1.26.629-1.87.084-1.87.085-1.089-.402a3.796 3.796 0 0 1-.24-.099 6.041 6.041 0 0 1-.545-.277 9.693 9.693 0 0 1-1.11-.727 5.709 5.709 0 0 1-.23-.187l-1.036-.886-.71-1.306a7.55 7.55 0 0 1-.152-.294 11.46 11.46 0 0 1-.314-.702 17.642 17.642 0 0 1-.554-1.527 9.1 9.1 0 0 1-.097-.34l-.405-1.557v-2.18a24.705 24.705 0 0 1 .04-1.42 17.962 17.962 0 0 1 .126-1.285 14.173 14.173 0 0 1 .133-.795 12.386 12.386 0 0 1 .397-1.488 11.71 11.71 0 0 1 .417-1.061c.053-.117.107-.233.163-.35l.686-1.414 1.224-1.099 1.223-1.1 1.238-.33a9.52 9.52 0 0 1 .581-.128 13.035 13.035 0 0 1 1.65-.196c.099-.004.193-.007.28-.007z"/>
+<path d="m323.296 50.381-2.655.46a9467.2 9467.2 0 0 0-16.281 2.872 14178.35 14178.35 0 0 1-18.786 3.313c-22 3.848-44.31 7.839-44.416 7.946-.07.07 1.64 10.158 3.803 22.416 2.162 12.258 3.94 22.517 3.95 22.798l.019.51-3.308 1.756c-12.508 6.64-22.784 15.792-30.58 27.239l-1.882 2.762 9.418 5.8a3575.83 3575.83 0 0 1 11.006 6.797c10.287 6.45 8.87 5.91 10.226 3.904 5.672-8.397 14.596-15.215 24.44-18.673l2.375-.834 33.04-5.812c18.171-3.197 33.084-5.857 33.138-5.91.101-.102-.429-3.156-8.654-49.813zM294.73 79.308l1.827.318c2.551.445 5.214 1.423 7.392 2.717l1.855 1.102 1.857 1.88 1.858 1.879.894 1.515c1.808 3.065 3.069 7.86 3.25 12.358l.09 2.249-14.788.068-14.786.068.138 1.523.138 1.523.613 1.306.614 1.305 1.028.998 1.028.998 1.366.646c.75.355 2.102.797 3.003.983l1.638.338 1.652-.307 1.651-.307 1.393-.705c.766-.387 2.152-1.335 3.08-2.105l1.686-1.4 5.083 1.636 5.083 1.636-1.164 1.6c-.64.88-1.924 2.28-2.853 3.113l-1.689 1.512-2.646 1.293-2.646 1.292-1.72.402c-.945.22-2.404.47-3.24.554-3.182.32-4.375.345-6.814.14l-2.513-.21-2.117-.547-2.116-.547-2.508-1.235-2.508-1.234-2.122-2.142-2.123-2.141-1-1.72c-1.715-2.952-2.566-6.473-2.57-10.626l-.002-2.292.391-2.042c1.536-8.027 7.238-14.325 14.962-16.525l1.978-.563 3.189-.152zm4.867 15.502c0-.666-.935-2.465-1.87-3.597l-.827-1-1.099-.563-1.098-.563-1.852-.12-1.853-.12-1.083.293c-.596.162-1.566.642-2.154 1.069l-1.07.775-.679 1.408c-.372.775-.756 1.736-.85 2.136l-.174.728h14.609z"/>
+</svg>
+
+</svg>
+<svg id="num-nav">
+<svg viewBox="0 0 12 9">
+  <path d="M4.124 6.925v-.436a.44.436 0 0 0-.44-.436.44.436 0 0 0 .44-.436v-.436a.586.581 0 0 0-.586-.581H2.366v.581h1.172v.581h-.586v.582h.586v.581H2.366v.581h1.172a.586.581 0 0 0 .586-.581"/>
+  <path d="M.461 4.6v.581h1.172v.581h-.586a.586.581 0 0 0-.586.582v1.162H2.22v-.581H1.047v-.581h.586a.586.581 0 0 0 .586-.582v-.58a.586.581 0 0 0-.586-.582Z"/>
+  <path d="M1.047 1.5a.586.581 0 0 0-.586.58v1.744a.586.581 0 0 0 .586.581h.586a.586.581 0 0 0 .586-.58V2.08a.586.581 0 0 0-.586-.58h-.586m0 .58h.586v1.744h-.586z"/>
+  <path d="M2.824 1.5v.58h.587v2.325h.586V1.5Z"/>
+  <path d="m5 2.318.647.414c.496-.67 1.174-1.102 2.004-1.192l-.04-.764a.371.372 0 0 1 .376-.373.375.376 0 0 1 .375.375l-.04.76c.83.096 1.505.528 2.004 1.192l.645-.414a.38.38 0 0 1 .513.137.369.369 0 0 1-.137.51l-.686.347a2.94 2.944 0 0 1 0 2.383l.685.35a.37.37 0 0 1 .138.509.377.377 0 0 1-.512.136l-.648-.414c-.495.67-1.173 1.102-2.003 1.192l.041.764a.371.372 0 0 1-.376.373.375.376 0 0 1-.376-.375l.038-.76c-.828-.096-1.504-.528-2.002-1.192l-.644.414a.38.38 0 0 1-.515-.137.369.369 0 0 1 .137-.511l.686-.346a2.94 2.944 0 0 1 0-2.383l-.685-.35a.37.37 0 0 1-.136-.51A.377.377 0 0 1 5 2.316m2.232 1.431c.156-.172.29-.285.519-.33l-.063-1.13c-.588.079-1.047.383-1.41.848l.954.612m1.317-.212c.104.06.191.132.266.212l.877-.61a2.225 2.228 0 0 0-.656-.57 1.903 1.905 0 0 0-.75-.28L8.23 3.413a1.106 1.107 0 0 1 .318.123m.436 1.304 1.01.514a2.214 2.217 0 0 0-.004-1.701l-1.016.51a1.051 1.052 0 0 1 .008.677m-.168.42a1.076 1.077 0 0 1-.595.33l.063 1.128c.588-.077 1.047-.381 1.41-.847l-.878-.611m-1.392.212c-.105-.06-.117-.132-.194-.215l-.95.614c.174.222.393.418.656.57.263.15.468.241.75.278l.059-1.123a1.147 1.148 0 0 1-.32-.123m-.438-1.305-1.008-.514a2.227 2.227 0 0 0 .002 1.701l1.016-.51a1.05 1.051 0 0 1-.008-.677z"/>
+</svg>
+
+</svg>
+</defs>/* end glyphs */
+<style>/* inherit to force styles through use tags */
+svg path {
+    fill: inherit;
+}
+
+/* font and background color specifications */
+svg.keymap {
+    font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
+    font-size: 14px;
+    font-kerning: normal;
+    text-rendering: optimizeLegibility;
+    fill: #24292e;
+}
+
+/* default key styling */
+rect.key {
+    fill: #f6f8fa;
+}
+
+rect.key, rect.combo {
+    stroke: #c9cccf;
+    stroke-width: 1;
+}
+
+/* default key side styling, only used is draw_key_sides is set */
+rect.side {
+    filter: brightness(90%);
+}
+
+/* color accent for combo boxes */
+rect.combo, rect.combo-separate {
+    fill: #cdf;
+}
+
+/* color accent for held keys */
+rect.held, rect.combo.held {
+    fill: #fdd;
+}
+
+/* color accent for ghost (optional) keys */
+rect.ghost, rect.combo.ghost {
+    stroke-dasharray: 4, 4;
+    stroke-width: 2;
+}
+
+text {
+    text-anchor: middle;
+    dominant-baseline: middle;
+}
+
+/* styling for layer labels */
+text.label {
+    font-weight: bold;
+    text-anchor: start;
+    stroke: white;
+    stroke-width: 2;
+    paint-order: stroke;
+}
+
+/* styling for combo tap, and key hold/shifted label text */
+text.combo, text.hold, text.shifted {
+    font-size: 11px;
+}
+
+text.hold {
+    text-anchor: middle;
+    dominant-baseline: auto;
+}
+
+text.shifted {
+    text-anchor: middle;
+    dominant-baseline: hanging;
+}
+
+/* styling for hold/shifted label text in combo box */
+text.combo.hold, text.combo.shifted {
+    font-size: 8px;
+}
+
+/* lighter symbol for transparent keys */
+text.trans {
+    fill: #7b7e81;
+}
+
+/* styling for combo dendrons */
+path.combo {
+    stroke-width: 1;
+    stroke: gray;
+    fill: none;
+}
+
+/* Start Tabler Icons Cleanup */
+/* cannot use height/width with glyphs */
+.icon-tabler > path {
+    fill: inherit;
+    stroke: inherit;
+    stroke-width: 2;
+}
+/* hide tabler's default box */
+.icon-tabler > path[stroke="none"][fill="none"] {
+    visibility: hidden;
+}
+/* End Tabler Icons Cleanup */
+
+/* Note, it is dumb, but SVG requires that ampersand be escaped (even in CSS!): &amp; */
+
+/* Nord color scheme */
+:root {
+    --dark1: #2e3440;
+    --dark2: #3b4252;
+    --dark3: #434c5e;
+    --dark4: #4c566a;
+   --light1: #d8dee9;
+   --light2: #e5e9f0;
+   --light3: #eceff4;
+    --blue1: #8fbcbb;
+    --blue2: #88c0d0;
+    --blue3: #81a1c1;
+    --blue4: #5e81ac;
+      --red: #bf616a;
+   --orange: #d08770;
+   --yellow: #ebcb8b;
+    --green: #a3be8c;
+   --purple: #b48ead;
+}
+
+.key rect {
+    stroke: var(--light3);
+    fill: var(--light3);
+}
+
+.tap {
+    fill: var(--dark1);
+    
+}
+
+.info {
+    &amp; .shifted, &amp; .hold {
+        fill: var(--dark1)
+    }
+}
+
+text.shifted, text.hold {
+  font-size: 8px;
+  fill: var(--blue4);
+}
+
+text.shifted {
+    dominant-baseline: hanging;
+    text-anchor: end;
+    translate: 22px 2px;
+}
+
+text.hold {
+  dominant-baseline: ideographic !important;
+  text-anchor: middle;
+}
+
+.held rect {
+    fill: var(--blue1);
+}
+
+.trans, .none, .ghost {
+    opacity: 0.8!important;
+    &amp; .tap {
+        fill: var(--blue2) !important;
+    }
+}
+
+/* Row 2,3,4 (alpha keys) */
+.keypos-23, .keypos-24, .keypos-25, .keypos-26, .keypos-27, .keypos-28, .keypos-29, .keypos-30, .keypos-31, .keypos-32,
+.keypos-35, .keypos-36, .keypos-37, .keypos-38, .keypos-39, .keypos-40, .keypos-41, .keypos-42, .keypos-43, .keypos-44,
+.keypos-47, .keypos-48, .keypos-49, .keypos-50, .keypos-51, .keypos-58, .keypos-59, .keypos-60, .keypos-61, .keypos-62
+{
+    &amp; rect {
+        fill: var(--light1);
+    }
+}
+
+/* Home keys */
+.keypos-35, .keypos-36, .keypos-37, .keypos-38, .keypos-41, .keypos-42, .keypos-43, .keypos-44
+{
+    &amp; rect {
+        stroke: var(--purple);
+    }
+}
+
+/* Thumb keys: */
+.keypos-52, .keypos-53, .keypos-54,     .keypos-55, .keypos-56, .keypos-57,
+.keypos-69, .keypos-70, .keypos-71,     .keypos-72, .keypos-73, .keypos-74
+{
+   /* TODO? */
+}
+
+/* Highlight WASD */
+.layer-Gaming {
+    &amp; .keypos-25 rect {
+        stroke: var(--purple);
+    }
+    &amp; .keypos-35 rect {
+        stroke: var(--light1);
+    }
+}
+</style>
+<g transform="translate(30, 0)" class="layer-default">
+<text x="0" y="28" class="label">default</text>
+<g transform="translate(0, 56)">
+<g transform="translate(28, 56)" class="key keypos-0">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">F1</text>
+</g>
+<g transform="translate(84, 56)" class="key keypos-1">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">F2</text>
+</g>
+<g transform="translate(140, 28)" class="key keypos-2">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">F3</text>
+</g>
+<g transform="translate(196, 28)" class="key keypos-3">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">F4</text>
+</g>
+<g transform="translate(252, 28)" class="key keypos-4">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">F5</text>
+</g>
+<g transform="translate(756, 28)" class="key keypos-5">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">F6</text>
+</g>
+<g transform="translate(812, 28)" class="key keypos-6">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">F7</text>
+</g>
+<g transform="translate(868, 28)" class="key keypos-7">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">F8</text>
+</g>
+<g transform="translate(924, 56)" class="key keypos-8">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">F9</text>
+</g>
+<g transform="translate(980, 56)" class="key keypos-9">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">F10</text>
+</g>
+<g transform="translate(28, 112)" class="key keypos-10">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">F11</text>
+</g>
+<g transform="translate(84, 112)" class="key keypos-11">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">1</text>
+<text x="0" y="-24" class="key shifted">!</text>
+</g>
+<g transform="translate(140, 84)" class="key keypos-12">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">2</text>
+<text x="0" y="-24" class="key shifted">&quot;</text>
+</g>
+<g transform="translate(196, 84)" class="key keypos-13">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">3</text>
+<text x="0" y="-24" class="key shifted">£</text>
+</g>
+<g transform="translate(252, 84)" class="key keypos-14">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">4</text>
+<text x="0" y="-24" class="key shifted">$</text>
+</g>
+<g transform="translate(308, 84)" class="key keypos-15">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">5</text>
+<text x="0" y="-24" class="key shifted">%</text>
+</g>
+<g transform="translate(700, 84)" class="key keypos-16">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">6</text>
+<text x="0" y="-24" class="key shifted">^</text>
+</g>
+<g transform="translate(756, 84)" class="key keypos-17">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">7</text>
+<text x="0" y="-24" class="key shifted">&amp;</text>
+</g>
+<g transform="translate(812, 84)" class="key keypos-18">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">8</text>
+<text x="0" y="-24" class="key shifted">*</text>
+</g>
+<g transform="translate(868, 84)" class="key keypos-19">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">9</text>
+<text x="0" y="-24" class="key shifted">(</text>
+</g>
+<g transform="translate(924, 112)" class="key keypos-20">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">0</text>
+<text x="0" y="-24" class="key shifted">)</text>
+</g>
+<g transform="translate(980, 112)" class="key keypos-21">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">F12</text>
+</g>
+<g transform="translate(28, 168)" class="key keypos-22">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(84, 168)" class="key keypos-23">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Q</text>
+</g>
+<g transform="translate(140, 140)" class="key keypos-24">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">W</text>
+</g>
+<g transform="translate(196, 140)" class="key keypos-25">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">F</text>
+</g>
+<g transform="translate(252, 140)" class="key keypos-26">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">P</text>
+</g>
+<g transform="translate(308, 140)" class="key keypos-27">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">B</text>
+</g>
+<g transform="translate(700, 140)" class="key keypos-28">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">J</text>
+</g>
+<g transform="translate(756, 140)" class="key keypos-29">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">L</text>
+</g>
+<g transform="translate(812, 140)" class="key keypos-30">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">U</text>
+</g>
+<g transform="translate(868, 140)" class="key keypos-31">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Y</text>
+</g>
+<g transform="translate(924, 168)" class="key keypos-32">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">&#x27;</text>
+<text x="0" y="-24" class="key shifted">&quot;</text>
+</g>
+<g transform="translate(980, 168)" class="key keypos-33">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(28, 224)" class="key keypos-34">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">_</text>
+<text x="0" y="-24" class="key shifted">\</text>
+</g>
+<g transform="translate(84, 224)" class="key keypos-35">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">A</text>
+</g>
+<g transform="translate(140, 196)" class="key keypos-36">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">R</text>
+</g>
+<g transform="translate(196, 196)" class="key keypos-37">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">S</text>
+</g>
+<g transform="translate(252, 196)" class="key keypos-38">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">T</text>
+</g>
+<g transform="translate(308, 196)" class="key keypos-39">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">G</text>
+</g>
+<g transform="translate(700, 196)" class="key keypos-40">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">M</text>
+</g>
+<g transform="translate(756, 196)" class="key keypos-41">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">N</text>
+</g>
+<g transform="translate(812, 196)" class="key keypos-42">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">E</text>
+</g>
+<g transform="translate(868, 196)" class="key keypos-43">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">I</text>
+</g>
+<g transform="translate(924, 224)" class="key keypos-44">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">O</text>
+</g>
+<g transform="translate(980, 224)" class="key keypos-45">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">-</text>
+<text x="0" y="-24" class="key shifted">/</text>
+</g>
+<g transform="translate(28, 280)" class="key keypos-46">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(84, 280)" class="key keypos-47">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Z</text>
+</g>
+<g transform="translate(140, 252)" class="key keypos-48">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">X</text>
+</g>
+<g transform="translate(196, 252)" class="key keypos-49">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">C</text>
+</g>
+<g transform="translate(252, 252)" class="key keypos-50">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">D</text>
+</g>
+<g transform="translate(308, 252)" class="key keypos-51">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">V</text>
+</g>
+<g transform="translate(371, 312) rotate(30.0)" class="key keypos-52">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:apple-keyboard-shift" xlink:href="#mdi:apple-keyboard-shift" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:apple-keyboard-shift"/>
+</g>
+<g transform="translate(420, 350) rotate(45.0)" class="key info keypos-53">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
+<use href="#num-nav" xlink:href="#num-nav" x="-9" y="-7" height="14" width="18.666666666666668" class="key info tap glyph num-nav"/>
+<text x="0" y="24" class="key info hold"><tspan style="font-size: 71%">Num/Nav</tspan></text>
+</g>
+<g transform="translate(458, 399) rotate(60.0)" class="key info keypos-54">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
+<use href="#mdi:monitor-dashboard" xlink:href="#mdi:monitor-dashboard" x="-7" y="-7" height="14" width="14.0" class="key info tap glyph mdi:monitor-dashboard"/>
+<text x="0" y="24" class="key info hold">Meta</text>
+</g>
+<g transform="translate(550, 399) rotate(-60.0)" class="key keypos-55">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Alt</text>
+</g>
+<g transform="translate(588, 350) rotate(-45.0)" class="key info keypos-56">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
+<use href="#num-nav" xlink:href="#num-nav" x="-9" y="-7" height="14" width="18.666666666666668" class="key info tap glyph num-nav"/>
+<text x="0" y="24" class="key info hold"><tspan style="font-size: 71%">Num/Nav</tspan></text>
+</g>
+<g transform="translate(637, 312) rotate(-30.0)" class="key keypos-57">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:apple-keyboard-shift" xlink:href="#mdi:apple-keyboard-shift" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:apple-keyboard-shift"/>
+</g>
+<g transform="translate(700, 252)" class="key keypos-58">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">K</text>
+</g>
+<g transform="translate(756, 252)" class="key keypos-59">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">H</text>
+</g>
+<g transform="translate(812, 252)" class="key keypos-60">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">,</text>
+<text x="0" y="-24" class="key shifted">;</text>
+</g>
+<g transform="translate(868, 252)" class="key keypos-61">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">.</text>
+<text x="0" y="-24" class="key shifted">:</text>
+</g>
+<g transform="translate(924, 280)" class="key keypos-62">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">?</text>
+<text x="0" y="-24" class="key shifted">!</text>
+</g>
+<g transform="translate(980, 280)" class="key keypos-63">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(28, 336)" class="key info keypos-64">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
+<use href="#mdi:controller" xlink:href="#mdi:controller" x="-7" y="-7" height="14" width="14.0" class="key info tap glyph mdi:controller"/>
+<text x="0" y="24" class="key info hold"><tspan style="font-size: 83%">Gaming</tspan></text>
+</g>
+<g transform="translate(84, 336)" class="key info keypos-65">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
+<use href="#moergo" xlink:href="#moergo" x="-21" y="-7" height="14" width="41.674418604651166" class="key info tap glyph moergo"/>
+<text x="0" y="24" class="key info hold">Magic</text>
+</g>
+<g transform="translate(140, 308)" class="key keypos-66">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(196, 308)" class="key keypos-67">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(252, 308)" class="key keypos-68">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(314, 347) rotate(20.0)" class="key keypos-69">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:backspace" xlink:href="#mdi:backspace" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:backspace"/>
+</g>
+<g transform="translate(369, 379) rotate(40.0)" class="key keypos-70">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Esc</text>
+<text x="0" y="24" class="key hold"><tspan style="font-size: 71%">symbols</tspan></text>
+</g>
+<g transform="translate(410, 427) rotate(60.0)" class="key keypos-71">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:keyboard-tab-reverse" xlink:href="#mdi:keyboard-tab-reverse" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:keyboard-tab-reverse"/>
+<text x="0" y="24" class="key hold">Ctrl</text>
+</g>
+<g transform="translate(598, 427) rotate(-60.0)" class="key keypos-72">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:keyboard-tab" xlink:href="#mdi:keyboard-tab" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:keyboard-tab"/>
+<text x="0" y="24" class="key hold">Ctrl</text>
+</g>
+<g transform="translate(639, 379) rotate(-40.0)" class="key keypos-73">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:keyboard-return" xlink:href="#mdi:keyboard-return" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:keyboard-return"/>
+<text x="0" y="24" class="key hold"><tspan style="font-size: 71%">symbols</tspan></text>
+</g>
+<g transform="translate(694, 347) rotate(-20.0)" class="key keypos-74">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:keyboard-space" xlink:href="#mdi:keyboard-space" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:keyboard-space"/>
+</g>
+<g transform="translate(756, 308)" class="key keypos-75">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(812, 308)" class="key keypos-76">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(868, 308)" class="key keypos-77">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(924, 336)" class="key keypos-78">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">AltGr</text>
+</g>
+<g transform="translate(980, 336)" class="key info keypos-79">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
+<use href="#mdi:keyboard-outline" xlink:href="#mdi:keyboard-outline" x="-7" y="-7" height="14" width="14.0" class="key info tap glyph mdi:keyboard-outline"/>
+<text x="0" y="24" class="key info hold"><tspan style="font-size: 83%">Qwerty</tspan></text>
+</g>
+<g class="combo combopos-0">
+<path d="M504,312 l-114,0" class="combo"/>
+<path d="M504,312 l114,0" class="combo"/>
+<rect rx="6" ry="6" x="490" y="299" width="28" height="26" class="combo"/>
+<use href="#mdi:apple-keyboard-caps" xlink:href="#mdi:apple-keyboard-caps" x="497" y="305" height="14" width="14.0" class="combo tap glyph mdi:apple-keyboard-caps"/>
+</g>
+<g class="combo combopos-1">
+<path d="M504,347 l-171,0" class="combo"/>
+<path d="M504,347 l171,0" class="combo"/>
+<rect rx="6" ry="6" x="490" y="334" width="28" height="26" class="combo"/>
+<text x="504" y="347" class="combo tap">_</text>
+</g>
+</g>
+</g>
+</svg>

--- a/img/glove80_gaming.svg
+++ b/img/glove80_gaming.svg
@@ -1,0 +1,626 @@
+<svg width="1068" height="577" viewBox="0 0 1068 577" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>/* start glyphs */
+<svg id="mdi:apple-keyboard-caps">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-apple-keyboard-caps" viewBox="0 0 24 24"><path d="M15,14V8H17.17L12,2.83L6.83,8H9V14H15M12,0L22,10H17V16H7V10H2L12,0M7,18H17V24H7V18M15,20H9V22H15V20Z" /></svg>
+</svg>
+<svg id="mdi:apple-keyboard-shift">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-apple-keyboard-shift" viewBox="0 0 24 24"><path d="M15,18V12H17.17L12,6.83L6.83,12H9V18H15M12,4L22,14H17V20H7V14H2L12,4Z" /></svg>
+</svg>
+<svg id="mdi:arrow-down-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-down-bold" viewBox="0 0 24 24"><path d="M9,4H15V12H19.84L12,19.84L4.16,12H9V4Z" /></svg>
+</svg>
+<svg id="mdi:arrow-left-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-left-bold" viewBox="0 0 24 24"><path d="M20,9V15H12V19.84L4.16,12L12,4.16V9H20Z" /></svg>
+</svg>
+<svg id="mdi:arrow-right-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-right-bold" viewBox="0 0 24 24"><path d="M4,15V9H12V4.16L19.84,12L12,19.84V15H4Z" /></svg>
+</svg>
+<svg id="mdi:arrow-up-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-up-bold" viewBox="0 0 24 24"><path d="M15,20H9V12H4.16L12,4.16L19.84,12H15V20Z" /></svg>
+</svg>
+<svg id="mdi:backspace">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-backspace" viewBox="0 0 24 24"><path d="M22,3H7C6.31,3 5.77,3.35 5.41,3.88L0,12L5.41,20.11C5.77,20.64 6.31,21 7,21H22A2,2 0 0,0 24,19V5A2,2 0 0,0 22,3M19,15.59L17.59,17L14,13.41L10.41,17L9,15.59L12.59,12L9,8.41L10.41,7L14,10.59L17.59,7L19,8.41L15.41,12" /></svg>
+</svg>
+<svg id="mdi:backspace-reverse-outline">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-backspace-reverse-outline" viewBox="0 0 24 24"><path d="M5,15.59L6.41,17L10,13.41L13.59,17L15,15.59L11.41,12L15,8.41L13.59,7L10,10.59L6.41,7L5,8.41L8.59,12L5,15.59M2,3A2,2 0 0,0 0,5V19A2,2 0 0,0 2,21H17C17.69,21 18.23,20.64 18.59,20.11L24,12L18.59,3.88C18.23,3.35 17.69,3 17,3H2M2,5H17L21.72,12L17,19H2V5Z" /></svg>
+</svg>
+<svg id="mdi:bluetooth">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-bluetooth" viewBox="0 0 24 24"><path d="M14.88,16.29L13,18.17V14.41M13,5.83L14.88,7.71L13,9.58M17.71,7.71L12,2H11V9.58L6.41,5L5,6.41L10.59,12L5,17.58L6.41,19L11,14.41V22H12L17.71,16.29L13.41,12L17.71,7.71Z" /></svg>
+</svg>
+<svg id="mdi:bluetooth-off">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-bluetooth-off" viewBox="0 0 24 24"><path d="M13,5.83L14.88,7.71L13.28,9.31L14.69,10.72L17.71,7.7L12,2H11V7.03L13,9.03M5.41,4L4,5.41L10.59,12L5,17.59L6.41,19L11,14.41V22H12L16.29,17.71L18.59,20L20,18.59M13,18.17V14.41L14.88,16.29" /></svg>
+</svg>
+<svg id="mdi:chevron-double-left">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-chevron-double-left" viewBox="0 0 24 24"><path d="M18.41,7.41L17,6L11,12L17,18L18.41,16.59L13.83,12L18.41,7.41M12.41,7.41L11,6L5,12L11,18L12.41,16.59L7.83,12L12.41,7.41Z" /></svg>
+</svg>
+<svg id="mdi:chevron-double-right">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-chevron-double-right" viewBox="0 0 24 24"><path d="M5.59,7.41L7,6L13,12L7,18L5.59,16.59L10.17,12L5.59,7.41M11.59,7.41L13,6L19,12L13,18L11.59,16.59L16.17,12L11.59,7.41Z" /></svg>
+</svg>
+<svg id="mdi:chevron-down">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-chevron-down" viewBox="0 0 24 24"><path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" /></svg>
+</svg>
+<svg id="mdi:controller">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-controller" viewBox="0 0 24 24"><path d="M7.97,16L5,19C4.67,19.3 4.23,19.5 3.75,19.5A1.75,1.75 0 0,1 2,17.75V17.5L3,10.12C3.21,7.81 5.14,6 7.5,6H16.5C18.86,6 20.79,7.81 21,10.12L22,17.5V17.75A1.75,1.75 0 0,1 20.25,19.5C19.77,19.5 19.33,19.3 19,19L16.03,16H7.97M7,8V10H5V11H7V13H8V11H10V10H8V8H7M16.5,8A0.75,0.75 0 0,0 15.75,8.75A0.75,0.75 0 0,0 16.5,9.5A0.75,0.75 0 0,0 17.25,8.75A0.75,0.75 0 0,0 16.5,8M14.75,9.75A0.75,0.75 0 0,0 14,10.5A0.75,0.75 0 0,0 14.75,11.25A0.75,0.75 0 0,0 15.5,10.5A0.75,0.75 0 0,0 14.75,9.75M18.25,9.75A0.75,0.75 0 0,0 17.5,10.5A0.75,0.75 0 0,0 18.25,11.25A0.75,0.75 0 0,0 19,10.5A0.75,0.75 0 0,0 18.25,9.75M16.5,11.5A0.75,0.75 0 0,0 15.75,12.25A0.75,0.75 0 0,0 16.5,13A0.75,0.75 0 0,0 17.25,12.25A0.75,0.75 0 0,0 16.5,11.5Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-outline">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-outline" viewBox="0 0 24 24"><path d="M4,5A2,2 0 0,0 2,7V17A2,2 0 0,0 4,19H20A2,2 0 0,0 22,17V7A2,2 0 0,0 20,5H4M4,7H20V17H4V7M5,8V10H7V8H5M8,8V10H10V8H8M11,8V10H13V8H11M14,8V10H16V8H14M17,8V10H19V8H17M5,11V13H7V11H5M8,11V13H10V11H8M11,11V13H13V11H11M14,11V13H16V11H14M17,11V13H19V11H17M8,14V16H16V14H8Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-return">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-return" viewBox="0 0 24 24"><path d="M19,7V11H5.83L9.41,7.41L8,6L2,12L8,18L9.41,16.58L5.83,13H21V7H19Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-space">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-space" viewBox="0 0 24 24"><path d="M3 15H5V19H19V15H21V19C21 20.1 20.1 21 19 21H5C3.9 21 3 20.1 3 19V15Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-tab">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-tab" viewBox="0 0 24 24"><path d="M20,18H22V6H20M11.59,7.41L15.17,11H1V13H15.17L11.59,16.58L13,18L19,12L13,6L11.59,7.41Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-tab-reverse">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-tab-reverse" viewBox="0 0 24 24"><path d="M4 6H2V18H4M11 6L5 12L11 18L12.41 16.58L8.83 13H23V11H8.83L12.41 7.41L11 6Z" /></svg>
+</svg>
+<svg id="mdi:monitor-dashboard">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-monitor-dashboard" viewBox="0 0 24 24"><path d="M21,16V4H3V16H21M21,2A2,2 0 0,1 23,4V16A2,2 0 0,1 21,18H14V20H16V22H8V20H10V18H3C1.89,18 1,17.1 1,16V4C1,2.89 1.89,2 3,2H21M5,6H14V11H5V6M15,6H19V8H15V6M19,9V14H15V9H19M5,12H9V14H5V12M10,12H14V14H10V12Z" /></svg>
+</svg>
+<svg id="mdi:play-pause">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-play-pause" viewBox="0 0 24 24"><path d="M3,5V19L11,12M13,19H16V5H13M18,5V19H21V5" /></svg>
+</svg>
+<svg id="mdi:skip-next">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-skip-next" viewBox="0 0 24 24"><path d="M16,18H18V6H16M6,18L14.5,12L6,6V18Z" /></svg>
+</svg>
+<svg id="mdi:skip-previous">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-skip-previous" viewBox="0 0 24 24"><path d="M6,18V6H8V18H6M9.5,12L18,6V18L9.5,12Z" /></svg>
+</svg>
+<svg id="mdi:usb">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-usb" viewBox="0 0 24 24"><path d="M15,7V11H16V13H13V5H15L12,1L9,5H11V13H8V10.93C8.7,10.56 9.2,9.85 9.2,9C9.2,7.78 8.21,6.8 7,6.8C5.78,6.8 4.8,7.78 4.8,9C4.8,9.85 5.3,10.56 6,10.93V13A2,2 0 0,0 8,15H11V18.05C10.29,18.41 9.8,19.15 9.8,20A2.2,2.2 0 0,0 12,22.2A2.2,2.2 0 0,0 14.2,20C14.2,19.15 13.71,18.41 13,18.05V15H16A2,2 0 0,0 18,13V11H19V7H15Z" /></svg>
+</svg>
+<svg id="mdi:volume-high">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-volume-high" viewBox="0 0 24 24"><path d="M14,3.23V5.29C16.89,6.15 19,8.83 19,12C19,15.17 16.89,17.84 14,18.7V20.77C18,19.86 21,16.28 21,12C21,7.72 18,4.14 14,3.23M16.5,12C16.5,10.23 15.5,8.71 14,7.97V16C15.5,15.29 16.5,13.76 16.5,12M3,9V15H7L12,20V4L7,9H3Z" /></svg>
+</svg>
+<svg id="mdi:volume-low">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-volume-low" viewBox="0 0 24 24"><path d="M7,9V15H11L16,20V4L11,9H7Z" /></svg>
+</svg>
+<svg id="mdi:volume-off">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-volume-off" viewBox="0 0 24 24"><path d="M12,4L9.91,6.09L12,8.18M4.27,3L3,4.27L7.73,9H3V15H7L12,20V13.27L16.25,17.53C15.58,18.04 14.83,18.46 14,18.7V20.77C15.38,20.45 16.63,19.82 17.68,18.96L19.73,21L21,19.73L12,10.73M19,12C19,12.94 18.8,13.82 18.46,14.64L19.97,16.15C20.62,14.91 21,13.5 21,12C21,7.72 18,4.14 14,3.23V5.29C16.89,6.15 19,8.83 19,12M16.5,12C16.5,10.23 15.5,8.71 14,7.97V10.18L16.45,12.63C16.5,12.43 16.5,12.21 16.5,12Z" /></svg>
+</svg>
+<svg id="moergo">
+<svg xml:space="preserve" viewBox="0 0 512 172">
+<path d="m60.09 80.108-.073-4.3-2.778-.046a288.998 288.998 0 0 1-3.245-.066l-.466-.02.07-9.061.07-9.062 1.777-.871c.978-.479 2.75-1.116 3.936-1.416l2.158-.546 1.938.098 1.937.098.741.549c.959.71 1.857 2.04 2.192 3.247l.266.957.002 12.37.001 12.369h18.786V75.94l-2.977-.004-2.976-.004-.335-.212-.334-.212.07-8.97.07-8.97 1.058-.598c.582-.329 1.951-.91 3.043-1.29l1.984-.691 2.513-.128 2.514-.127 1.188.615 1.189.615.578.87c.317.478.705 1.466.862 2.196l.284 1.326v24.052h18.785v-8.45l-3.24-.075-3.242-.074-.163-10.451-.163-10.451-.412-1.755c-.227-.965-.712-2.347-1.08-3.07l-.666-1.317-1.367-1.23-1.367-1.228-1.227-.55c-.676-.303-2.002-.717-2.948-.921l-1.72-.37-2.249-.004c-5.224-.006-8.928 1.154-15.272 4.78l-1.118.638-.767-.926c-.421-.51-1.437-1.388-2.257-1.952l-1.491-1.026-1.784-.654-1.784-.654-2.679-.142-2.678-.143-1.82.334c-2.344.43-5.837 1.628-7.714 2.644-.811.44-1.633.8-1.825.8h-.35v-3.176H34.749v8.731h6.62l-.068 11.012-.07 11.011-3.24-.045-3.242-.045v8.759h25.414zm307.77 35.396v-4.359l-3.903-.073-3.902-.073.035-4.101.035-4.101.462-1.853c.255-1.018.814-2.551 1.243-3.406l.78-1.555 1.203-1.287 1.203-1.286 1.393-.682 1.394-.681 2.079-.37c1.143-.205 2.766-.376 3.605-.38l1.527-.01-.071-5.754-.072-5.755-1.984.057c-2.584.073-4.265.478-6.216 1.496l-1.586.828-1.752 1.72-1.751 1.72-1.028 2.175-1.028 2.176-.331.007-.33.007V80.44h-17.994v8.466h6.88v22.225h-7.408v4.189c0 2.304.08 4.269.177 4.366l.176.176h27.164zm90.354-36.19-2.91.152-2.91.152-1.978.56c-1.087.308-2.884 1.032-3.992 1.609l-2.015 1.048-1.74 1.435-1.74 1.435-1.213 1.7c-2.198 3.08-3.398 6.55-3.74 10.81l-.178 2.2.3 2.459.301 2.459.63 1.98.628 1.98 1.085 1.827 1.085 1.826 1.653 1.634c4.082 4.035 8.828 5.94 15.046 6.043l2.016.033 2.327-.406 2.327-.406 1.743-.69c.959-.38 2.576-1.226 3.595-1.879l1.852-1.187 1.772-1.802 1.773-1.801 1.18-2.463 1.181-2.463.471-1.852.472-1.852.008-3.704.008-3.705-.35-1.587c-.52-2.36-1.549-4.81-2.85-6.788l-1.16-1.76-1.59-1.473c-2.927-2.71-6.842-4.546-11.12-5.216zm-3.213 9.327h3.301l1.28.546a8.732 8.732 0 0 1 .803.395 7.563 7.563 0 0 1 .96.64 6.99 6.99 0 0 1 1.385 1.453 7.746 7.746 0 0 1 .482.76 8.846 8.846 0 0 1 .419.847 10.375 10.375 0 0 1 .356.937 12.694 12.694 0 0 1 .297 1.029 16.376 16.376 0 0 1 .24 1.126 20.138 20.138 0 0 1 .181 1.224l.278 2.288-.27 2.375a31.867 31.867 0 0 1-.136 1.031 21.21 21.21 0 0 1-.162.925 15.296 15.296 0 0 1-.193.834 11.573 11.573 0 0 1-.23.76 9.573 9.573 0 0 1-.429 1.032 8.657 8.657 0 0 1-.542.952 10.276 10.276 0 0 1-.433.616l-.95 1.255-1.447.73-1.448.73-1.455.119a9.456 9.456 0 0 1-.638.03c-.11.002-.222.002-.332.002a11.503 11.503 0 0 1-.937-.045 5.823 5.823 0 0 1-.258-.03 3.177 3.177 0 0 1-.215-.039h-.001a8.305 8.305 0 0 1-1.082-.314 7.362 7.362 0 0 1-.746-.327 6.734 6.734 0 0 1-1.526-1.076 6.94 6.94 0 0 1-.74-.815 7.83 7.83 0 0 1-.494-.709 9.102 9.102 0 0 1-.443-.793 10.732 10.732 0 0 1-.392-.88 13.103 13.103 0 0 1-.343-.966 15.588 15.588 0 0 1-.202-.692l-.41-1.53.004-2.91.003-2.91.273-1.42a11.718 11.718 0 0 1 .274-1.062 18.563 18.563 0 0 1 .707-1.932l.706-1.573 1.046-.895 1.045-.895 1.207-.411zM132.263 11.697c-.034.046-2.106 11.691-4.604 25.88-2.498 14.188-5.55 31.51-6.78 38.493l-2.236 12.697.188.168c.104.093 14.892 2.745 32.864 5.894l32.676 5.726 2.514.825c1.382.453 3.96 1.517 5.727 2.363l3.214 1.539 2.607 1.766c5.134 3.477 9.088 7.32 12.861 12.496l1.6 2.196.291-.117c.16-.064 5.886-3.578 12.726-7.809 6.84-4.23 13.297-8.202 14.35-8.826 1.054-.623 1.917-1.227 1.919-1.342.006-.405-3.296-5.123-5.728-8.184l-2.463-3.1-3.378-3.386c-6.352-6.369-13.625-11.71-21.146-15.528-1.333-.677-2.54-1.375-2.685-1.552l-.261-.32 3.932-22.225c2.163-12.224 3.937-22.464 3.942-22.755l.008-.529-3.373-.595c-3.298-.583-37.653-6.632-64.983-11.443-7.545-1.328-13.747-2.378-13.782-2.332Zm36.233 30.314 2.35.444a24.764 24.764 0 0 1 2.44.592 23.266 23.266 0 0 1 2.777 1.03 22.678 22.678 0 0 1 2.19 1.123l1.554.907 1.945 1.848 1.945 1.848 1.024 1.626a20.183 20.183 0 0 1 .697 1.224 29.839 29.839 0 0 1 .695 1.405 21.308 21.308 0 0 1 .367.846l.737 1.85.392 2.251.391 2.252-.133 3.704-.133 3.704-.574 1.977a12.6 12.6 0 0 1-.137.439 19.653 19.653 0 0 1-.364 1.012 30.436 30.436 0 0 1-.905 2.107c-.076.158-.151.308-.224.448l-1.055 2.028-1.468 1.623a23.44 23.44 0 0 1-1.64 1.64 22.31 22.31 0 0 1-2.387 1.874 21.434 21.434 0 0 1-3.978 2.124 21.751 21.751 0 0 1-2.154.743l-1.97.568-3.837.108-3.836.108-2.25-.5a24.587 24.587 0 0 1-2.104-.565 23.215 23.215 0 0 1-1.993-.737 22.27 22.27 0 0 1-2.473-1.238 21.003 21.003 0 0 1-2.243-1.512 20.136 20.136 0 0 1-2.452-2.253 19.478 19.478 0 0 1-4.082-6.862 20.427 20.427 0 0 1-.215-.655l-.541-1.755-.293-2.61-.293-2.61.16-2.116a28.936 28.936 0 0 1 .326-2.643 25.64 25.64 0 0 1 .56-2.485 22.955 22.955 0 0 1 .793-2.32 20.977 20.977 0 0 1 .654-1.452 19.989 19.989 0 0 1 1.166-2.032 19.022 19.022 0 0 1 1.893-2.424 18.685 18.685 0 0 1 2.268-2.086 19.407 19.407 0 0 1 1.94-1.334 20.624 20.624 0 0 1 2.14-1.13 22.523 22.523 0 0 1 2.333-.917c.27-.09.544-.176.82-.257l2.298-.68 3.44-.14zm.595 31.233 1.124-.524.866-1.012.866-1.012.458-1.28c.252-.704.584-2.287.738-3.518l.278-2.238-.18-1.73c-.1-.953-.402-2.45-.67-3.33l-.49-1.599-.96-1.122-.962-1.123-1.029-.525c-.566-.288-1.554-.597-2.195-.684l-1.166-.16-1.387.332-1.387.333-1.039.939c-1.296 1.171-1.992 2.515-2.47 4.773l-.373 1.757-.005 2.147c-.002 1.18.114 2.788.258 3.572l.262 1.425.862 1.709.863 1.709 1.058.741 1.058.742 1.19.228a7.103 7.103 0 0 0 4.432-.55zm232.503 6.57-2.513.004-2.514.004-1.587.465c-.873.256-2.382.88-3.352 1.388l-1.765.924-1.686 1.632c-2.91 2.818-4.732 6.224-5.647 10.554l-.406 1.927v6.614l.393 1.866c1.764 8.345 7.056 13.98 14.045 14.951l1.93.269 1.799-.288 1.8-.287 1.868-.78 1.869-.779 2.313-1.738 2.314-1.737.3.186.303.186-.182 3.099c-.418 7.15-2.43 9.735-8.29 10.646l-1.955.304-2.253-.326-2.254-.326-1.762-.663c-.97-.365-2.146-.89-2.614-1.166l-.85-.501-2.436 3.359c-1.34 1.847-2.68 3.633-2.979 3.968l-.544.61.39.269c.215.148 1.224.677 2.244 1.176l1.855.905 2.575.654c4.317 1.095 9.784 1.447 14.354.924v-.001c3.285-.376 5.177-.9 7.805-2.159l2.249-1.077 1.765-1.792 1.764-1.793.937-1.947c.516-1.072 1.2-2.957 1.52-4.19l.584-2.244.109-16.999.109-17h6.573V80.44h-18.785v4.498h-.381c-.21 0-.987-.58-1.726-1.29l-1.346-1.289-1.575-.84c-.867-.462-2.204-1.034-2.97-1.272zm1.147 9.62h1.273l1.222.418 1.224.416 1.195 1.053 1.196 1.052.806 1.64.805 1.64.297 2.304.296 2.304-.306 2.053-.305 2.053-.624 1.363a6.734 6.734 0 0 1-.145.295 9.744 9.744 0 0 1-.364.643 13.175 13.175 0 0 1-.638.95 8.675 8.675 0 0 1-.212.275c-.07.085-.136.164-.2.235l-.936 1.036-1.26.63-1.26.629-1.87.084-1.87.085-1.089-.402a3.796 3.796 0 0 1-.24-.099 6.041 6.041 0 0 1-.545-.277 9.693 9.693 0 0 1-1.11-.727 5.709 5.709 0 0 1-.23-.187l-1.036-.886-.71-1.306a7.55 7.55 0 0 1-.152-.294 11.46 11.46 0 0 1-.314-.702 17.642 17.642 0 0 1-.554-1.527 9.1 9.1 0 0 1-.097-.34l-.405-1.557v-2.18a24.705 24.705 0 0 1 .04-1.42 17.962 17.962 0 0 1 .126-1.285 14.173 14.173 0 0 1 .133-.795 12.386 12.386 0 0 1 .397-1.488 11.71 11.71 0 0 1 .417-1.061c.053-.117.107-.233.163-.35l.686-1.414 1.224-1.099 1.223-1.1 1.238-.33a9.52 9.52 0 0 1 .581-.128 13.035 13.035 0 0 1 1.65-.196c.099-.004.193-.007.28-.007z"/>
+<path d="m323.296 50.381-2.655.46a9467.2 9467.2 0 0 0-16.281 2.872 14178.35 14178.35 0 0 1-18.786 3.313c-22 3.848-44.31 7.839-44.416 7.946-.07.07 1.64 10.158 3.803 22.416 2.162 12.258 3.94 22.517 3.95 22.798l.019.51-3.308 1.756c-12.508 6.64-22.784 15.792-30.58 27.239l-1.882 2.762 9.418 5.8a3575.83 3575.83 0 0 1 11.006 6.797c10.287 6.45 8.87 5.91 10.226 3.904 5.672-8.397 14.596-15.215 24.44-18.673l2.375-.834 33.04-5.812c18.171-3.197 33.084-5.857 33.138-5.91.101-.102-.429-3.156-8.654-49.813zM294.73 79.308l1.827.318c2.551.445 5.214 1.423 7.392 2.717l1.855 1.102 1.857 1.88 1.858 1.879.894 1.515c1.808 3.065 3.069 7.86 3.25 12.358l.09 2.249-14.788.068-14.786.068.138 1.523.138 1.523.613 1.306.614 1.305 1.028.998 1.028.998 1.366.646c.75.355 2.102.797 3.003.983l1.638.338 1.652-.307 1.651-.307 1.393-.705c.766-.387 2.152-1.335 3.08-2.105l1.686-1.4 5.083 1.636 5.083 1.636-1.164 1.6c-.64.88-1.924 2.28-2.853 3.113l-1.689 1.512-2.646 1.293-2.646 1.292-1.72.402c-.945.22-2.404.47-3.24.554-3.182.32-4.375.345-6.814.14l-2.513-.21-2.117-.547-2.116-.547-2.508-1.235-2.508-1.234-2.122-2.142-2.123-2.141-1-1.72c-1.715-2.952-2.566-6.473-2.57-10.626l-.002-2.292.391-2.042c1.536-8.027 7.238-14.325 14.962-16.525l1.978-.563 3.189-.152zm4.867 15.502c0-.666-.935-2.465-1.87-3.597l-.827-1-1.099-.563-1.098-.563-1.852-.12-1.853-.12-1.083.293c-.596.162-1.566.642-2.154 1.069l-1.07.775-.679 1.408c-.372.775-.756 1.736-.85 2.136l-.174.728h14.609z"/>
+</svg>
+
+</svg>
+<svg id="num-nav">
+<svg viewBox="0 0 12 9">
+  <path d="M4.124 6.925v-.436a.44.436 0 0 0-.44-.436.44.436 0 0 0 .44-.436v-.436a.586.581 0 0 0-.586-.581H2.366v.581h1.172v.581h-.586v.582h.586v.581H2.366v.581h1.172a.586.581 0 0 0 .586-.581"/>
+  <path d="M.461 4.6v.581h1.172v.581h-.586a.586.581 0 0 0-.586.582v1.162H2.22v-.581H1.047v-.581h.586a.586.581 0 0 0 .586-.582v-.58a.586.581 0 0 0-.586-.582Z"/>
+  <path d="M1.047 1.5a.586.581 0 0 0-.586.58v1.744a.586.581 0 0 0 .586.581h.586a.586.581 0 0 0 .586-.58V2.08a.586.581 0 0 0-.586-.58h-.586m0 .58h.586v1.744h-.586z"/>
+  <path d="M2.824 1.5v.58h.587v2.325h.586V1.5Z"/>
+  <path d="m5 2.318.647.414c.496-.67 1.174-1.102 2.004-1.192l-.04-.764a.371.372 0 0 1 .376-.373.375.376 0 0 1 .375.375l-.04.76c.83.096 1.505.528 2.004 1.192l.645-.414a.38.38 0 0 1 .513.137.369.369 0 0 1-.137.51l-.686.347a2.94 2.944 0 0 1 0 2.383l.685.35a.37.37 0 0 1 .138.509.377.377 0 0 1-.512.136l-.648-.414c-.495.67-1.173 1.102-2.003 1.192l.041.764a.371.372 0 0 1-.376.373.375.376 0 0 1-.376-.375l.038-.76c-.828-.096-1.504-.528-2.002-1.192l-.644.414a.38.38 0 0 1-.515-.137.369.369 0 0 1 .137-.511l.686-.346a2.94 2.944 0 0 1 0-2.383l-.685-.35a.37.37 0 0 1-.136-.51A.377.377 0 0 1 5 2.316m2.232 1.431c.156-.172.29-.285.519-.33l-.063-1.13c-.588.079-1.047.383-1.41.848l.954.612m1.317-.212c.104.06.191.132.266.212l.877-.61a2.225 2.228 0 0 0-.656-.57 1.903 1.905 0 0 0-.75-.28L8.23 3.413a1.106 1.107 0 0 1 .318.123m.436 1.304 1.01.514a2.214 2.217 0 0 0-.004-1.701l-1.016.51a1.051 1.052 0 0 1 .008.677m-.168.42a1.076 1.077 0 0 1-.595.33l.063 1.128c.588-.077 1.047-.381 1.41-.847l-.878-.611m-1.392.212c-.105-.06-.117-.132-.194-.215l-.95.614c.174.222.393.418.656.57.263.15.468.241.75.278l.059-1.123a1.147 1.148 0 0 1-.32-.123m-.438-1.305-1.008-.514a2.227 2.227 0 0 0 .002 1.701l1.016-.51a1.05 1.051 0 0 1-.008-.677z"/>
+</svg>
+
+</svg>
+</defs>/* end glyphs */
+<style>/* inherit to force styles through use tags */
+svg path {
+    fill: inherit;
+}
+
+/* font and background color specifications */
+svg.keymap {
+    font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
+    font-size: 14px;
+    font-kerning: normal;
+    text-rendering: optimizeLegibility;
+    fill: #24292e;
+}
+
+/* default key styling */
+rect.key {
+    fill: #f6f8fa;
+}
+
+rect.key, rect.combo {
+    stroke: #c9cccf;
+    stroke-width: 1;
+}
+
+/* default key side styling, only used is draw_key_sides is set */
+rect.side {
+    filter: brightness(90%);
+}
+
+/* color accent for combo boxes */
+rect.combo, rect.combo-separate {
+    fill: #cdf;
+}
+
+/* color accent for held keys */
+rect.held, rect.combo.held {
+    fill: #fdd;
+}
+
+/* color accent for ghost (optional) keys */
+rect.ghost, rect.combo.ghost {
+    stroke-dasharray: 4, 4;
+    stroke-width: 2;
+}
+
+text {
+    text-anchor: middle;
+    dominant-baseline: middle;
+}
+
+/* styling for layer labels */
+text.label {
+    font-weight: bold;
+    text-anchor: start;
+    stroke: white;
+    stroke-width: 2;
+    paint-order: stroke;
+}
+
+/* styling for combo tap, and key hold/shifted label text */
+text.combo, text.hold, text.shifted {
+    font-size: 11px;
+}
+
+text.hold {
+    text-anchor: middle;
+    dominant-baseline: auto;
+}
+
+text.shifted {
+    text-anchor: middle;
+    dominant-baseline: hanging;
+}
+
+/* styling for hold/shifted label text in combo box */
+text.combo.hold, text.combo.shifted {
+    font-size: 8px;
+}
+
+/* lighter symbol for transparent keys */
+text.trans {
+    fill: #7b7e81;
+}
+
+/* styling for combo dendrons */
+path.combo {
+    stroke-width: 1;
+    stroke: gray;
+    fill: none;
+}
+
+/* Start Tabler Icons Cleanup */
+/* cannot use height/width with glyphs */
+.icon-tabler > path {
+    fill: inherit;
+    stroke: inherit;
+    stroke-width: 2;
+}
+/* hide tabler's default box */
+.icon-tabler > path[stroke="none"][fill="none"] {
+    visibility: hidden;
+}
+/* End Tabler Icons Cleanup */
+
+/* Note, it is dumb, but SVG requires that ampersand be escaped (even in CSS!): &amp; */
+
+/* Nord color scheme */
+:root {
+    --dark1: #2e3440;
+    --dark2: #3b4252;
+    --dark3: #434c5e;
+    --dark4: #4c566a;
+   --light1: #d8dee9;
+   --light2: #e5e9f0;
+   --light3: #eceff4;
+    --blue1: #8fbcbb;
+    --blue2: #88c0d0;
+    --blue3: #81a1c1;
+    --blue4: #5e81ac;
+      --red: #bf616a;
+   --orange: #d08770;
+   --yellow: #ebcb8b;
+    --green: #a3be8c;
+   --purple: #b48ead;
+}
+
+.key rect {
+    stroke: var(--light3);
+    fill: var(--light3);
+}
+
+.tap {
+    fill: var(--dark1);
+    
+}
+
+.info {
+    &amp; .shifted, &amp; .hold {
+        fill: var(--dark1)
+    }
+}
+
+text.shifted, text.hold {
+  font-size: 8px;
+  fill: var(--blue4);
+}
+
+text.shifted {
+    dominant-baseline: hanging;
+    text-anchor: end;
+    translate: 22px 2px;
+}
+
+text.hold {
+  dominant-baseline: ideographic !important;
+  text-anchor: middle;
+}
+
+.held rect {
+    fill: var(--blue1);
+}
+
+.trans, .none, .ghost {
+    opacity: 0.8!important;
+    &amp; .tap {
+        fill: var(--blue2) !important;
+    }
+}
+
+/* Row 2,3,4 (alpha keys) */
+.keypos-23, .keypos-24, .keypos-25, .keypos-26, .keypos-27, .keypos-28, .keypos-29, .keypos-30, .keypos-31, .keypos-32,
+.keypos-35, .keypos-36, .keypos-37, .keypos-38, .keypos-39, .keypos-40, .keypos-41, .keypos-42, .keypos-43, .keypos-44,
+.keypos-47, .keypos-48, .keypos-49, .keypos-50, .keypos-51, .keypos-58, .keypos-59, .keypos-60, .keypos-61, .keypos-62
+{
+    &amp; rect {
+        fill: var(--light1);
+    }
+}
+
+/* Home keys */
+.keypos-35, .keypos-36, .keypos-37, .keypos-38, .keypos-41, .keypos-42, .keypos-43, .keypos-44
+{
+    &amp; rect {
+        stroke: var(--purple);
+    }
+}
+
+/* Thumb keys: */
+.keypos-52, .keypos-53, .keypos-54,     .keypos-55, .keypos-56, .keypos-57,
+.keypos-69, .keypos-70, .keypos-71,     .keypos-72, .keypos-73, .keypos-74
+{
+   /* TODO? */
+}
+
+/* Highlight WASD */
+.layer-Gaming {
+    &amp; .keypos-25 rect {
+        stroke: var(--purple);
+    }
+    &amp; .keypos-35 rect {
+        stroke: var(--light1);
+    }
+}
+</style>
+<g transform="translate(30, 0)" class="layer-gaming">
+<text x="0" y="28" class="label">gaming</text>
+<g transform="translate(0, 56)">
+<g transform="translate(28, 56)" class="key trans keypos-0">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 56)" class="key trans keypos-1">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(140, 28)" class="key trans keypos-2">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(196, 28)" class="key trans keypos-3">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(252, 28)" class="key trans keypos-4">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(756, 28)" class="key trans keypos-5">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(812, 28)" class="key trans keypos-6">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(868, 28)" class="key trans keypos-7">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(924, 56)" class="key trans keypos-8">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(980, 56)" class="key trans keypos-9">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 112)" class="key trans keypos-10">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 112)" class="key trans keypos-11">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(140, 84)" class="key trans keypos-12">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(196, 84)" class="key trans keypos-13">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(252, 84)" class="key trans keypos-14">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(308, 84)" class="key trans keypos-15">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(700, 84)" class="key trans keypos-16">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(756, 84)" class="key trans keypos-17">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(812, 84)" class="key trans keypos-18">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(868, 84)" class="key trans keypos-19">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(924, 112)" class="key trans keypos-20">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(980, 112)" class="key trans keypos-21">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 168)" class="key keypos-22">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(84, 168)" class="key keypos-23">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:keyboard-tab" xlink:href="#mdi:keyboard-tab" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:keyboard-tab"/>
+</g>
+<g transform="translate(140, 140)" class="key keypos-24">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Q</text>
+</g>
+<g transform="translate(196, 140)" class="key keypos-25">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">W</text>
+</g>
+<g transform="translate(252, 140)" class="key keypos-26">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">E</text>
+</g>
+<g transform="translate(308, 140)" class="key keypos-27">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">R</text>
+</g>
+<g transform="translate(700, 140)" class="key trans keypos-28">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(756, 140)" class="key trans keypos-29">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(812, 140)" class="key trans keypos-30">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(868, 140)" class="key trans keypos-31">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(924, 168)" class="key trans keypos-32">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(980, 168)" class="key trans keypos-33">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 224)" class="key keypos-34">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(84, 224)" class="key keypos-35">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:apple-keyboard-shift" xlink:href="#mdi:apple-keyboard-shift" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:apple-keyboard-shift"/>
+</g>
+<g transform="translate(140, 196)" class="key keypos-36">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">A</text>
+</g>
+<g transform="translate(196, 196)" class="key keypos-37">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">S</text>
+</g>
+<g transform="translate(252, 196)" class="key keypos-38">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">D</text>
+</g>
+<g transform="translate(308, 196)" class="key keypos-39">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">F</text>
+</g>
+<g transform="translate(700, 196)" class="key trans keypos-40">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(756, 196)" class="key trans keypos-41">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(812, 196)" class="key trans keypos-42">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(868, 196)" class="key trans keypos-43">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(924, 224)" class="key trans keypos-44">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(980, 224)" class="key trans keypos-45">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 280)" class="key keypos-46">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(84, 280)" class="key keypos-47">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Ctrl</text>
+</g>
+<g transform="translate(140, 252)" class="key keypos-48">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Z</text>
+</g>
+<g transform="translate(196, 252)" class="key keypos-49">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">X</text>
+</g>
+<g transform="translate(252, 252)" class="key keypos-50">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">C</text>
+</g>
+<g transform="translate(308, 252)" class="key keypos-51">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">V</text>
+</g>
+<g transform="translate(371, 312) rotate(30.0)" class="key keypos-52">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">T</text>
+</g>
+<g transform="translate(420, 350) rotate(45.0)" class="key keypos-53">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">G</text>
+</g>
+<g transform="translate(458, 399) rotate(60.0)" class="key keypos-54">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">B</text>
+</g>
+<g transform="translate(550, 399) rotate(-60.0)" class="key trans keypos-55">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(588, 350) rotate(-45.0)" class="key trans keypos-56">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(637, 312) rotate(-30.0)" class="key trans keypos-57">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(700, 252)" class="key trans keypos-58">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(756, 252)" class="key trans keypos-59">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(812, 252)" class="key trans keypos-60">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(868, 252)" class="key trans keypos-61">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(924, 280)" class="key trans keypos-62">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(980, 280)" class="key trans keypos-63">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 336)" class="key info keypos-64">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
+<use href="#mdi:controller" xlink:href="#mdi:controller" x="-7" y="-7" height="14" width="14.0" class="key info tap glyph mdi:controller"/>
+<text x="0" y="24" class="key info hold"><tspan style="font-size: 83%">Gaming</tspan></text>
+</g>
+<g transform="translate(84, 336)" class="key keypos-65">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Alt</text>
+</g>
+<g transform="translate(140, 308)" class="key keypos-66">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(196, 308)" class="key keypos-67">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(252, 308)" class="key keypos-68">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(314, 347) rotate(20.0)" class="key keypos-69">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:keyboard-space" xlink:href="#mdi:keyboard-space" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:keyboard-space"/>
+</g>
+<g transform="translate(369, 379) rotate(40.0)" class="key keypos-70">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Esc</text>
+</g>
+<g transform="translate(410, 427) rotate(60.0)" class="key keypos-71">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">`</text>
+</g>
+<g transform="translate(598, 427) rotate(-60.0)" class="key trans keypos-72">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(639, 379) rotate(-40.0)" class="key trans keypos-73">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(694, 347) rotate(-20.0)" class="key trans keypos-74">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(756, 308)" class="key trans keypos-75">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(812, 308)" class="key trans keypos-76">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(868, 308)" class="key trans keypos-77">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(924, 336)" class="key trans keypos-78">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(980, 336)" class="key trans keypos-79">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+</g>
+</g>
+</svg>

--- a/img/glove80_magic.svg
+++ b/img/glove80_magic.svg
@@ -1,0 +1,598 @@
+<svg width="1068" height="577" viewBox="0 0 1068 577" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>/* start glyphs */
+<svg id="mdi:apple-keyboard-caps">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-apple-keyboard-caps" viewBox="0 0 24 24"><path d="M15,14V8H17.17L12,2.83L6.83,8H9V14H15M12,0L22,10H17V16H7V10H2L12,0M7,18H17V24H7V18M15,20H9V22H15V20Z" /></svg>
+</svg>
+<svg id="mdi:apple-keyboard-shift">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-apple-keyboard-shift" viewBox="0 0 24 24"><path d="M15,18V12H17.17L12,6.83L6.83,12H9V18H15M12,4L22,14H17V20H7V14H2L12,4Z" /></svg>
+</svg>
+<svg id="mdi:arrow-down-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-down-bold" viewBox="0 0 24 24"><path d="M9,4H15V12H19.84L12,19.84L4.16,12H9V4Z" /></svg>
+</svg>
+<svg id="mdi:arrow-left-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-left-bold" viewBox="0 0 24 24"><path d="M20,9V15H12V19.84L4.16,12L12,4.16V9H20Z" /></svg>
+</svg>
+<svg id="mdi:arrow-right-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-right-bold" viewBox="0 0 24 24"><path d="M4,15V9H12V4.16L19.84,12L12,19.84V15H4Z" /></svg>
+</svg>
+<svg id="mdi:arrow-up-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-up-bold" viewBox="0 0 24 24"><path d="M15,20H9V12H4.16L12,4.16L19.84,12H15V20Z" /></svg>
+</svg>
+<svg id="mdi:backspace">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-backspace" viewBox="0 0 24 24"><path d="M22,3H7C6.31,3 5.77,3.35 5.41,3.88L0,12L5.41,20.11C5.77,20.64 6.31,21 7,21H22A2,2 0 0,0 24,19V5A2,2 0 0,0 22,3M19,15.59L17.59,17L14,13.41L10.41,17L9,15.59L12.59,12L9,8.41L10.41,7L14,10.59L17.59,7L19,8.41L15.41,12" /></svg>
+</svg>
+<svg id="mdi:backspace-reverse-outline">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-backspace-reverse-outline" viewBox="0 0 24 24"><path d="M5,15.59L6.41,17L10,13.41L13.59,17L15,15.59L11.41,12L15,8.41L13.59,7L10,10.59L6.41,7L5,8.41L8.59,12L5,15.59M2,3A2,2 0 0,0 0,5V19A2,2 0 0,0 2,21H17C17.69,21 18.23,20.64 18.59,20.11L24,12L18.59,3.88C18.23,3.35 17.69,3 17,3H2M2,5H17L21.72,12L17,19H2V5Z" /></svg>
+</svg>
+<svg id="mdi:bluetooth">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-bluetooth" viewBox="0 0 24 24"><path d="M14.88,16.29L13,18.17V14.41M13,5.83L14.88,7.71L13,9.58M17.71,7.71L12,2H11V9.58L6.41,5L5,6.41L10.59,12L5,17.58L6.41,19L11,14.41V22H12L17.71,16.29L13.41,12L17.71,7.71Z" /></svg>
+</svg>
+<svg id="mdi:bluetooth-off">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-bluetooth-off" viewBox="0 0 24 24"><path d="M13,5.83L14.88,7.71L13.28,9.31L14.69,10.72L17.71,7.7L12,2H11V7.03L13,9.03M5.41,4L4,5.41L10.59,12L5,17.59L6.41,19L11,14.41V22H12L16.29,17.71L18.59,20L20,18.59M13,18.17V14.41L14.88,16.29" /></svg>
+</svg>
+<svg id="mdi:chevron-double-left">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-chevron-double-left" viewBox="0 0 24 24"><path d="M18.41,7.41L17,6L11,12L17,18L18.41,16.59L13.83,12L18.41,7.41M12.41,7.41L11,6L5,12L11,18L12.41,16.59L7.83,12L12.41,7.41Z" /></svg>
+</svg>
+<svg id="mdi:chevron-double-right">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-chevron-double-right" viewBox="0 0 24 24"><path d="M5.59,7.41L7,6L13,12L7,18L5.59,16.59L10.17,12L5.59,7.41M11.59,7.41L13,6L19,12L13,18L11.59,16.59L16.17,12L11.59,7.41Z" /></svg>
+</svg>
+<svg id="mdi:chevron-down">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-chevron-down" viewBox="0 0 24 24"><path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" /></svg>
+</svg>
+<svg id="mdi:controller">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-controller" viewBox="0 0 24 24"><path d="M7.97,16L5,19C4.67,19.3 4.23,19.5 3.75,19.5A1.75,1.75 0 0,1 2,17.75V17.5L3,10.12C3.21,7.81 5.14,6 7.5,6H16.5C18.86,6 20.79,7.81 21,10.12L22,17.5V17.75A1.75,1.75 0 0,1 20.25,19.5C19.77,19.5 19.33,19.3 19,19L16.03,16H7.97M7,8V10H5V11H7V13H8V11H10V10H8V8H7M16.5,8A0.75,0.75 0 0,0 15.75,8.75A0.75,0.75 0 0,0 16.5,9.5A0.75,0.75 0 0,0 17.25,8.75A0.75,0.75 0 0,0 16.5,8M14.75,9.75A0.75,0.75 0 0,0 14,10.5A0.75,0.75 0 0,0 14.75,11.25A0.75,0.75 0 0,0 15.5,10.5A0.75,0.75 0 0,0 14.75,9.75M18.25,9.75A0.75,0.75 0 0,0 17.5,10.5A0.75,0.75 0 0,0 18.25,11.25A0.75,0.75 0 0,0 19,10.5A0.75,0.75 0 0,0 18.25,9.75M16.5,11.5A0.75,0.75 0 0,0 15.75,12.25A0.75,0.75 0 0,0 16.5,13A0.75,0.75 0 0,0 17.25,12.25A0.75,0.75 0 0,0 16.5,11.5Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-outline">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-outline" viewBox="0 0 24 24"><path d="M4,5A2,2 0 0,0 2,7V17A2,2 0 0,0 4,19H20A2,2 0 0,0 22,17V7A2,2 0 0,0 20,5H4M4,7H20V17H4V7M5,8V10H7V8H5M8,8V10H10V8H8M11,8V10H13V8H11M14,8V10H16V8H14M17,8V10H19V8H17M5,11V13H7V11H5M8,11V13H10V11H8M11,11V13H13V11H11M14,11V13H16V11H14M17,11V13H19V11H17M8,14V16H16V14H8Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-return">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-return" viewBox="0 0 24 24"><path d="M19,7V11H5.83L9.41,7.41L8,6L2,12L8,18L9.41,16.58L5.83,13H21V7H19Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-space">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-space" viewBox="0 0 24 24"><path d="M3 15H5V19H19V15H21V19C21 20.1 20.1 21 19 21H5C3.9 21 3 20.1 3 19V15Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-tab">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-tab" viewBox="0 0 24 24"><path d="M20,18H22V6H20M11.59,7.41L15.17,11H1V13H15.17L11.59,16.58L13,18L19,12L13,6L11.59,7.41Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-tab-reverse">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-tab-reverse" viewBox="0 0 24 24"><path d="M4 6H2V18H4M11 6L5 12L11 18L12.41 16.58L8.83 13H23V11H8.83L12.41 7.41L11 6Z" /></svg>
+</svg>
+<svg id="mdi:monitor-dashboard">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-monitor-dashboard" viewBox="0 0 24 24"><path d="M21,16V4H3V16H21M21,2A2,2 0 0,1 23,4V16A2,2 0 0,1 21,18H14V20H16V22H8V20H10V18H3C1.89,18 1,17.1 1,16V4C1,2.89 1.89,2 3,2H21M5,6H14V11H5V6M15,6H19V8H15V6M19,9V14H15V9H19M5,12H9V14H5V12M10,12H14V14H10V12Z" /></svg>
+</svg>
+<svg id="mdi:play-pause">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-play-pause" viewBox="0 0 24 24"><path d="M3,5V19L11,12M13,19H16V5H13M18,5V19H21V5" /></svg>
+</svg>
+<svg id="mdi:skip-next">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-skip-next" viewBox="0 0 24 24"><path d="M16,18H18V6H16M6,18L14.5,12L6,6V18Z" /></svg>
+</svg>
+<svg id="mdi:skip-previous">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-skip-previous" viewBox="0 0 24 24"><path d="M6,18V6H8V18H6M9.5,12L18,6V18L9.5,12Z" /></svg>
+</svg>
+<svg id="mdi:usb">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-usb" viewBox="0 0 24 24"><path d="M15,7V11H16V13H13V5H15L12,1L9,5H11V13H8V10.93C8.7,10.56 9.2,9.85 9.2,9C9.2,7.78 8.21,6.8 7,6.8C5.78,6.8 4.8,7.78 4.8,9C4.8,9.85 5.3,10.56 6,10.93V13A2,2 0 0,0 8,15H11V18.05C10.29,18.41 9.8,19.15 9.8,20A2.2,2.2 0 0,0 12,22.2A2.2,2.2 0 0,0 14.2,20C14.2,19.15 13.71,18.41 13,18.05V15H16A2,2 0 0,0 18,13V11H19V7H15Z" /></svg>
+</svg>
+<svg id="mdi:volume-high">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-volume-high" viewBox="0 0 24 24"><path d="M14,3.23V5.29C16.89,6.15 19,8.83 19,12C19,15.17 16.89,17.84 14,18.7V20.77C18,19.86 21,16.28 21,12C21,7.72 18,4.14 14,3.23M16.5,12C16.5,10.23 15.5,8.71 14,7.97V16C15.5,15.29 16.5,13.76 16.5,12M3,9V15H7L12,20V4L7,9H3Z" /></svg>
+</svg>
+<svg id="mdi:volume-low">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-volume-low" viewBox="0 0 24 24"><path d="M7,9V15H11L16,20V4L11,9H7Z" /></svg>
+</svg>
+<svg id="mdi:volume-off">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-volume-off" viewBox="0 0 24 24"><path d="M12,4L9.91,6.09L12,8.18M4.27,3L3,4.27L7.73,9H3V15H7L12,20V13.27L16.25,17.53C15.58,18.04 14.83,18.46 14,18.7V20.77C15.38,20.45 16.63,19.82 17.68,18.96L19.73,21L21,19.73L12,10.73M19,12C19,12.94 18.8,13.82 18.46,14.64L19.97,16.15C20.62,14.91 21,13.5 21,12C21,7.72 18,4.14 14,3.23V5.29C16.89,6.15 19,8.83 19,12M16.5,12C16.5,10.23 15.5,8.71 14,7.97V10.18L16.45,12.63C16.5,12.43 16.5,12.21 16.5,12Z" /></svg>
+</svg>
+<svg id="moergo">
+<svg xml:space="preserve" viewBox="0 0 512 172">
+<path d="m60.09 80.108-.073-4.3-2.778-.046a288.998 288.998 0 0 1-3.245-.066l-.466-.02.07-9.061.07-9.062 1.777-.871c.978-.479 2.75-1.116 3.936-1.416l2.158-.546 1.938.098 1.937.098.741.549c.959.71 1.857 2.04 2.192 3.247l.266.957.002 12.37.001 12.369h18.786V75.94l-2.977-.004-2.976-.004-.335-.212-.334-.212.07-8.97.07-8.97 1.058-.598c.582-.329 1.951-.91 3.043-1.29l1.984-.691 2.513-.128 2.514-.127 1.188.615 1.189.615.578.87c.317.478.705 1.466.862 2.196l.284 1.326v24.052h18.785v-8.45l-3.24-.075-3.242-.074-.163-10.451-.163-10.451-.412-1.755c-.227-.965-.712-2.347-1.08-3.07l-.666-1.317-1.367-1.23-1.367-1.228-1.227-.55c-.676-.303-2.002-.717-2.948-.921l-1.72-.37-2.249-.004c-5.224-.006-8.928 1.154-15.272 4.78l-1.118.638-.767-.926c-.421-.51-1.437-1.388-2.257-1.952l-1.491-1.026-1.784-.654-1.784-.654-2.679-.142-2.678-.143-1.82.334c-2.344.43-5.837 1.628-7.714 2.644-.811.44-1.633.8-1.825.8h-.35v-3.176H34.749v8.731h6.62l-.068 11.012-.07 11.011-3.24-.045-3.242-.045v8.759h25.414zm307.77 35.396v-4.359l-3.903-.073-3.902-.073.035-4.101.035-4.101.462-1.853c.255-1.018.814-2.551 1.243-3.406l.78-1.555 1.203-1.287 1.203-1.286 1.393-.682 1.394-.681 2.079-.37c1.143-.205 2.766-.376 3.605-.38l1.527-.01-.071-5.754-.072-5.755-1.984.057c-2.584.073-4.265.478-6.216 1.496l-1.586.828-1.752 1.72-1.751 1.72-1.028 2.175-1.028 2.176-.331.007-.33.007V80.44h-17.994v8.466h6.88v22.225h-7.408v4.189c0 2.304.08 4.269.177 4.366l.176.176h27.164zm90.354-36.19-2.91.152-2.91.152-1.978.56c-1.087.308-2.884 1.032-3.992 1.609l-2.015 1.048-1.74 1.435-1.74 1.435-1.213 1.7c-2.198 3.08-3.398 6.55-3.74 10.81l-.178 2.2.3 2.459.301 2.459.63 1.98.628 1.98 1.085 1.827 1.085 1.826 1.653 1.634c4.082 4.035 8.828 5.94 15.046 6.043l2.016.033 2.327-.406 2.327-.406 1.743-.69c.959-.38 2.576-1.226 3.595-1.879l1.852-1.187 1.772-1.802 1.773-1.801 1.18-2.463 1.181-2.463.471-1.852.472-1.852.008-3.704.008-3.705-.35-1.587c-.52-2.36-1.549-4.81-2.85-6.788l-1.16-1.76-1.59-1.473c-2.927-2.71-6.842-4.546-11.12-5.216zm-3.213 9.327h3.301l1.28.546a8.732 8.732 0 0 1 .803.395 7.563 7.563 0 0 1 .96.64 6.99 6.99 0 0 1 1.385 1.453 7.746 7.746 0 0 1 .482.76 8.846 8.846 0 0 1 .419.847 10.375 10.375 0 0 1 .356.937 12.694 12.694 0 0 1 .297 1.029 16.376 16.376 0 0 1 .24 1.126 20.138 20.138 0 0 1 .181 1.224l.278 2.288-.27 2.375a31.867 31.867 0 0 1-.136 1.031 21.21 21.21 0 0 1-.162.925 15.296 15.296 0 0 1-.193.834 11.573 11.573 0 0 1-.23.76 9.573 9.573 0 0 1-.429 1.032 8.657 8.657 0 0 1-.542.952 10.276 10.276 0 0 1-.433.616l-.95 1.255-1.447.73-1.448.73-1.455.119a9.456 9.456 0 0 1-.638.03c-.11.002-.222.002-.332.002a11.503 11.503 0 0 1-.937-.045 5.823 5.823 0 0 1-.258-.03 3.177 3.177 0 0 1-.215-.039h-.001a8.305 8.305 0 0 1-1.082-.314 7.362 7.362 0 0 1-.746-.327 6.734 6.734 0 0 1-1.526-1.076 6.94 6.94 0 0 1-.74-.815 7.83 7.83 0 0 1-.494-.709 9.102 9.102 0 0 1-.443-.793 10.732 10.732 0 0 1-.392-.88 13.103 13.103 0 0 1-.343-.966 15.588 15.588 0 0 1-.202-.692l-.41-1.53.004-2.91.003-2.91.273-1.42a11.718 11.718 0 0 1 .274-1.062 18.563 18.563 0 0 1 .707-1.932l.706-1.573 1.046-.895 1.045-.895 1.207-.411zM132.263 11.697c-.034.046-2.106 11.691-4.604 25.88-2.498 14.188-5.55 31.51-6.78 38.493l-2.236 12.697.188.168c.104.093 14.892 2.745 32.864 5.894l32.676 5.726 2.514.825c1.382.453 3.96 1.517 5.727 2.363l3.214 1.539 2.607 1.766c5.134 3.477 9.088 7.32 12.861 12.496l1.6 2.196.291-.117c.16-.064 5.886-3.578 12.726-7.809 6.84-4.23 13.297-8.202 14.35-8.826 1.054-.623 1.917-1.227 1.919-1.342.006-.405-3.296-5.123-5.728-8.184l-2.463-3.1-3.378-3.386c-6.352-6.369-13.625-11.71-21.146-15.528-1.333-.677-2.54-1.375-2.685-1.552l-.261-.32 3.932-22.225c2.163-12.224 3.937-22.464 3.942-22.755l.008-.529-3.373-.595c-3.298-.583-37.653-6.632-64.983-11.443-7.545-1.328-13.747-2.378-13.782-2.332Zm36.233 30.314 2.35.444a24.764 24.764 0 0 1 2.44.592 23.266 23.266 0 0 1 2.777 1.03 22.678 22.678 0 0 1 2.19 1.123l1.554.907 1.945 1.848 1.945 1.848 1.024 1.626a20.183 20.183 0 0 1 .697 1.224 29.839 29.839 0 0 1 .695 1.405 21.308 21.308 0 0 1 .367.846l.737 1.85.392 2.251.391 2.252-.133 3.704-.133 3.704-.574 1.977a12.6 12.6 0 0 1-.137.439 19.653 19.653 0 0 1-.364 1.012 30.436 30.436 0 0 1-.905 2.107c-.076.158-.151.308-.224.448l-1.055 2.028-1.468 1.623a23.44 23.44 0 0 1-1.64 1.64 22.31 22.31 0 0 1-2.387 1.874 21.434 21.434 0 0 1-3.978 2.124 21.751 21.751 0 0 1-2.154.743l-1.97.568-3.837.108-3.836.108-2.25-.5a24.587 24.587 0 0 1-2.104-.565 23.215 23.215 0 0 1-1.993-.737 22.27 22.27 0 0 1-2.473-1.238 21.003 21.003 0 0 1-2.243-1.512 20.136 20.136 0 0 1-2.452-2.253 19.478 19.478 0 0 1-4.082-6.862 20.427 20.427 0 0 1-.215-.655l-.541-1.755-.293-2.61-.293-2.61.16-2.116a28.936 28.936 0 0 1 .326-2.643 25.64 25.64 0 0 1 .56-2.485 22.955 22.955 0 0 1 .793-2.32 20.977 20.977 0 0 1 .654-1.452 19.989 19.989 0 0 1 1.166-2.032 19.022 19.022 0 0 1 1.893-2.424 18.685 18.685 0 0 1 2.268-2.086 19.407 19.407 0 0 1 1.94-1.334 20.624 20.624 0 0 1 2.14-1.13 22.523 22.523 0 0 1 2.333-.917c.27-.09.544-.176.82-.257l2.298-.68 3.44-.14zm.595 31.233 1.124-.524.866-1.012.866-1.012.458-1.28c.252-.704.584-2.287.738-3.518l.278-2.238-.18-1.73c-.1-.953-.402-2.45-.67-3.33l-.49-1.599-.96-1.122-.962-1.123-1.029-.525c-.566-.288-1.554-.597-2.195-.684l-1.166-.16-1.387.332-1.387.333-1.039.939c-1.296 1.171-1.992 2.515-2.47 4.773l-.373 1.757-.005 2.147c-.002 1.18.114 2.788.258 3.572l.262 1.425.862 1.709.863 1.709 1.058.741 1.058.742 1.19.228a7.103 7.103 0 0 0 4.432-.55zm232.503 6.57-2.513.004-2.514.004-1.587.465c-.873.256-2.382.88-3.352 1.388l-1.765.924-1.686 1.632c-2.91 2.818-4.732 6.224-5.647 10.554l-.406 1.927v6.614l.393 1.866c1.764 8.345 7.056 13.98 14.045 14.951l1.93.269 1.799-.288 1.8-.287 1.868-.78 1.869-.779 2.313-1.738 2.314-1.737.3.186.303.186-.182 3.099c-.418 7.15-2.43 9.735-8.29 10.646l-1.955.304-2.253-.326-2.254-.326-1.762-.663c-.97-.365-2.146-.89-2.614-1.166l-.85-.501-2.436 3.359c-1.34 1.847-2.68 3.633-2.979 3.968l-.544.61.39.269c.215.148 1.224.677 2.244 1.176l1.855.905 2.575.654c4.317 1.095 9.784 1.447 14.354.924v-.001c3.285-.376 5.177-.9 7.805-2.159l2.249-1.077 1.765-1.792 1.764-1.793.937-1.947c.516-1.072 1.2-2.957 1.52-4.19l.584-2.244.109-16.999.109-17h6.573V80.44h-18.785v4.498h-.381c-.21 0-.987-.58-1.726-1.29l-1.346-1.289-1.575-.84c-.867-.462-2.204-1.034-2.97-1.272zm1.147 9.62h1.273l1.222.418 1.224.416 1.195 1.053 1.196 1.052.806 1.64.805 1.64.297 2.304.296 2.304-.306 2.053-.305 2.053-.624 1.363a6.734 6.734 0 0 1-.145.295 9.744 9.744 0 0 1-.364.643 13.175 13.175 0 0 1-.638.95 8.675 8.675 0 0 1-.212.275c-.07.085-.136.164-.2.235l-.936 1.036-1.26.63-1.26.629-1.87.084-1.87.085-1.089-.402a3.796 3.796 0 0 1-.24-.099 6.041 6.041 0 0 1-.545-.277 9.693 9.693 0 0 1-1.11-.727 5.709 5.709 0 0 1-.23-.187l-1.036-.886-.71-1.306a7.55 7.55 0 0 1-.152-.294 11.46 11.46 0 0 1-.314-.702 17.642 17.642 0 0 1-.554-1.527 9.1 9.1 0 0 1-.097-.34l-.405-1.557v-2.18a24.705 24.705 0 0 1 .04-1.42 17.962 17.962 0 0 1 .126-1.285 14.173 14.173 0 0 1 .133-.795 12.386 12.386 0 0 1 .397-1.488 11.71 11.71 0 0 1 .417-1.061c.053-.117.107-.233.163-.35l.686-1.414 1.224-1.099 1.223-1.1 1.238-.33a9.52 9.52 0 0 1 .581-.128 13.035 13.035 0 0 1 1.65-.196c.099-.004.193-.007.28-.007z"/>
+<path d="m323.296 50.381-2.655.46a9467.2 9467.2 0 0 0-16.281 2.872 14178.35 14178.35 0 0 1-18.786 3.313c-22 3.848-44.31 7.839-44.416 7.946-.07.07 1.64 10.158 3.803 22.416 2.162 12.258 3.94 22.517 3.95 22.798l.019.51-3.308 1.756c-12.508 6.64-22.784 15.792-30.58 27.239l-1.882 2.762 9.418 5.8a3575.83 3575.83 0 0 1 11.006 6.797c10.287 6.45 8.87 5.91 10.226 3.904 5.672-8.397 14.596-15.215 24.44-18.673l2.375-.834 33.04-5.812c18.171-3.197 33.084-5.857 33.138-5.91.101-.102-.429-3.156-8.654-49.813zM294.73 79.308l1.827.318c2.551.445 5.214 1.423 7.392 2.717l1.855 1.102 1.857 1.88 1.858 1.879.894 1.515c1.808 3.065 3.069 7.86 3.25 12.358l.09 2.249-14.788.068-14.786.068.138 1.523.138 1.523.613 1.306.614 1.305 1.028.998 1.028.998 1.366.646c.75.355 2.102.797 3.003.983l1.638.338 1.652-.307 1.651-.307 1.393-.705c.766-.387 2.152-1.335 3.08-2.105l1.686-1.4 5.083 1.636 5.083 1.636-1.164 1.6c-.64.88-1.924 2.28-2.853 3.113l-1.689 1.512-2.646 1.293-2.646 1.292-1.72.402c-.945.22-2.404.47-3.24.554-3.182.32-4.375.345-6.814.14l-2.513-.21-2.117-.547-2.116-.547-2.508-1.235-2.508-1.234-2.122-2.142-2.123-2.141-1-1.72c-1.715-2.952-2.566-6.473-2.57-10.626l-.002-2.292.391-2.042c1.536-8.027 7.238-14.325 14.962-16.525l1.978-.563 3.189-.152zm4.867 15.502c0-.666-.935-2.465-1.87-3.597l-.827-1-1.099-.563-1.098-.563-1.852-.12-1.853-.12-1.083.293c-.596.162-1.566.642-2.154 1.069l-1.07.775-.679 1.408c-.372.775-.756 1.736-.85 2.136l-.174.728h14.609z"/>
+</svg>
+
+</svg>
+<svg id="num-nav">
+<svg viewBox="0 0 12 9">
+  <path d="M4.124 6.925v-.436a.44.436 0 0 0-.44-.436.44.436 0 0 0 .44-.436v-.436a.586.581 0 0 0-.586-.581H2.366v.581h1.172v.581h-.586v.582h.586v.581H2.366v.581h1.172a.586.581 0 0 0 .586-.581"/>
+  <path d="M.461 4.6v.581h1.172v.581h-.586a.586.581 0 0 0-.586.582v1.162H2.22v-.581H1.047v-.581h.586a.586.581 0 0 0 .586-.582v-.58a.586.581 0 0 0-.586-.582Z"/>
+  <path d="M1.047 1.5a.586.581 0 0 0-.586.58v1.744a.586.581 0 0 0 .586.581h.586a.586.581 0 0 0 .586-.58V2.08a.586.581 0 0 0-.586-.58h-.586m0 .58h.586v1.744h-.586z"/>
+  <path d="M2.824 1.5v.58h.587v2.325h.586V1.5Z"/>
+  <path d="m5 2.318.647.414c.496-.67 1.174-1.102 2.004-1.192l-.04-.764a.371.372 0 0 1 .376-.373.375.376 0 0 1 .375.375l-.04.76c.83.096 1.505.528 2.004 1.192l.645-.414a.38.38 0 0 1 .513.137.369.369 0 0 1-.137.51l-.686.347a2.94 2.944 0 0 1 0 2.383l.685.35a.37.37 0 0 1 .138.509.377.377 0 0 1-.512.136l-.648-.414c-.495.67-1.173 1.102-2.003 1.192l.041.764a.371.372 0 0 1-.376.373.375.376 0 0 1-.376-.375l.038-.76c-.828-.096-1.504-.528-2.002-1.192l-.644.414a.38.38 0 0 1-.515-.137.369.369 0 0 1 .137-.511l.686-.346a2.94 2.944 0 0 1 0-2.383l-.685-.35a.37.37 0 0 1-.136-.51A.377.377 0 0 1 5 2.316m2.232 1.431c.156-.172.29-.285.519-.33l-.063-1.13c-.588.079-1.047.383-1.41.848l.954.612m1.317-.212c.104.06.191.132.266.212l.877-.61a2.225 2.228 0 0 0-.656-.57 1.903 1.905 0 0 0-.75-.28L8.23 3.413a1.106 1.107 0 0 1 .318.123m.436 1.304 1.01.514a2.214 2.217 0 0 0-.004-1.701l-1.016.51a1.051 1.052 0 0 1 .008.677m-.168.42a1.076 1.077 0 0 1-.595.33l.063 1.128c.588-.077 1.047-.381 1.41-.847l-.878-.611m-1.392.212c-.105-.06-.117-.132-.194-.215l-.95.614c.174.222.393.418.656.57.263.15.468.241.75.278l.059-1.123a1.147 1.148 0 0 1-.32-.123m-.438-1.305-1.008-.514a2.227 2.227 0 0 0 .002 1.701l1.016-.51a1.05 1.051 0 0 1-.008-.677z"/>
+</svg>
+
+</svg>
+</defs>/* end glyphs */
+<style>/* inherit to force styles through use tags */
+svg path {
+    fill: inherit;
+}
+
+/* font and background color specifications */
+svg.keymap {
+    font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
+    font-size: 14px;
+    font-kerning: normal;
+    text-rendering: optimizeLegibility;
+    fill: #24292e;
+}
+
+/* default key styling */
+rect.key {
+    fill: #f6f8fa;
+}
+
+rect.key, rect.combo {
+    stroke: #c9cccf;
+    stroke-width: 1;
+}
+
+/* default key side styling, only used is draw_key_sides is set */
+rect.side {
+    filter: brightness(90%);
+}
+
+/* color accent for combo boxes */
+rect.combo, rect.combo-separate {
+    fill: #cdf;
+}
+
+/* color accent for held keys */
+rect.held, rect.combo.held {
+    fill: #fdd;
+}
+
+/* color accent for ghost (optional) keys */
+rect.ghost, rect.combo.ghost {
+    stroke-dasharray: 4, 4;
+    stroke-width: 2;
+}
+
+text {
+    text-anchor: middle;
+    dominant-baseline: middle;
+}
+
+/* styling for layer labels */
+text.label {
+    font-weight: bold;
+    text-anchor: start;
+    stroke: white;
+    stroke-width: 2;
+    paint-order: stroke;
+}
+
+/* styling for combo tap, and key hold/shifted label text */
+text.combo, text.hold, text.shifted {
+    font-size: 11px;
+}
+
+text.hold {
+    text-anchor: middle;
+    dominant-baseline: auto;
+}
+
+text.shifted {
+    text-anchor: middle;
+    dominant-baseline: hanging;
+}
+
+/* styling for hold/shifted label text in combo box */
+text.combo.hold, text.combo.shifted {
+    font-size: 8px;
+}
+
+/* lighter symbol for transparent keys */
+text.trans {
+    fill: #7b7e81;
+}
+
+/* styling for combo dendrons */
+path.combo {
+    stroke-width: 1;
+    stroke: gray;
+    fill: none;
+}
+
+/* Start Tabler Icons Cleanup */
+/* cannot use height/width with glyphs */
+.icon-tabler > path {
+    fill: inherit;
+    stroke: inherit;
+    stroke-width: 2;
+}
+/* hide tabler's default box */
+.icon-tabler > path[stroke="none"][fill="none"] {
+    visibility: hidden;
+}
+/* End Tabler Icons Cleanup */
+
+/* Note, it is dumb, but SVG requires that ampersand be escaped (even in CSS!): &amp; */
+
+/* Nord color scheme */
+:root {
+    --dark1: #2e3440;
+    --dark2: #3b4252;
+    --dark3: #434c5e;
+    --dark4: #4c566a;
+   --light1: #d8dee9;
+   --light2: #e5e9f0;
+   --light3: #eceff4;
+    --blue1: #8fbcbb;
+    --blue2: #88c0d0;
+    --blue3: #81a1c1;
+    --blue4: #5e81ac;
+      --red: #bf616a;
+   --orange: #d08770;
+   --yellow: #ebcb8b;
+    --green: #a3be8c;
+   --purple: #b48ead;
+}
+
+.key rect {
+    stroke: var(--light3);
+    fill: var(--light3);
+}
+
+.tap {
+    fill: var(--dark1);
+    
+}
+
+.info {
+    &amp; .shifted, &amp; .hold {
+        fill: var(--dark1)
+    }
+}
+
+text.shifted, text.hold {
+  font-size: 8px;
+  fill: var(--blue4);
+}
+
+text.shifted {
+    dominant-baseline: hanging;
+    text-anchor: end;
+    translate: 22px 2px;
+}
+
+text.hold {
+  dominant-baseline: ideographic !important;
+  text-anchor: middle;
+}
+
+.held rect {
+    fill: var(--blue1);
+}
+
+.trans, .none, .ghost {
+    opacity: 0.8!important;
+    &amp; .tap {
+        fill: var(--blue2) !important;
+    }
+}
+
+/* Row 2,3,4 (alpha keys) */
+.keypos-23, .keypos-24, .keypos-25, .keypos-26, .keypos-27, .keypos-28, .keypos-29, .keypos-30, .keypos-31, .keypos-32,
+.keypos-35, .keypos-36, .keypos-37, .keypos-38, .keypos-39, .keypos-40, .keypos-41, .keypos-42, .keypos-43, .keypos-44,
+.keypos-47, .keypos-48, .keypos-49, .keypos-50, .keypos-51, .keypos-58, .keypos-59, .keypos-60, .keypos-61, .keypos-62
+{
+    &amp; rect {
+        fill: var(--light1);
+    }
+}
+
+/* Home keys */
+.keypos-35, .keypos-36, .keypos-37, .keypos-38, .keypos-41, .keypos-42, .keypos-43, .keypos-44
+{
+    &amp; rect {
+        stroke: var(--purple);
+    }
+}
+
+/* Thumb keys: */
+.keypos-52, .keypos-53, .keypos-54,     .keypos-55, .keypos-56, .keypos-57,
+.keypos-69, .keypos-70, .keypos-71,     .keypos-72, .keypos-73, .keypos-74
+{
+   /* TODO? */
+}
+
+/* Highlight WASD */
+.layer-Gaming {
+    &amp; .keypos-25 rect {
+        stroke: var(--purple);
+    }
+    &amp; .keypos-35 rect {
+        stroke: var(--light1);
+    }
+}
+</style>
+<g transform="translate(30, 0)" class="layer-magic">
+<text x="0" y="28" class="label">magic</text>
+<g transform="translate(0, 56)">
+<g transform="translate(28, 56)" class="key info keypos-0">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
+<use href="#mdi:bluetooth-off" xlink:href="#mdi:bluetooth-off" x="-7" y="-7" height="14" width="14.0" class="key info tap glyph mdi:bluetooth-off"/>
+<text x="0" y="24" class="key info hold">Clear</text>
+</g>
+<g transform="translate(84, 56)" class="key keypos-1">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(140, 28)" class="key keypos-2">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(196, 28)" class="key keypos-3">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(252, 28)" class="key keypos-4">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(756, 28)" class="key keypos-5">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(812, 28)" class="key keypos-6">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(868, 28)" class="key keypos-7">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(924, 56)" class="key keypos-8">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(980, 56)" class="key info keypos-9">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
+<use href="#mdi:bluetooth-off" xlink:href="#mdi:bluetooth-off" x="-7" y="-7" height="14" width="14.0" class="key info tap glyph mdi:bluetooth-off"/>
+<text x="0" y="24" class="key info hold"><tspan style="font-size: 71%">Clr All</tspan></text>
+</g>
+<g transform="translate(28, 112)" class="key keypos-10">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(84, 112)" class="key keypos-11">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(140, 84)" class="key keypos-12">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(196, 84)" class="key keypos-13">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(252, 84)" class="key keypos-14">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(308, 84)" class="key keypos-15">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(700, 84)" class="key keypos-16">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(756, 84)" class="key keypos-17">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(812, 84)" class="key keypos-18">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(868, 84)" class="key keypos-19">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(924, 112)" class="key keypos-20">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(980, 112)" class="key keypos-21">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(28, 168)" class="key keypos-22">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(84, 168)" class="key keypos-23">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">RGB</tspan><tspan x="0" dy="1.2em">SPI</tspan>
+</text>
+</g>
+<g transform="translate(140, 140)" class="key keypos-24">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">RGB</tspan><tspan x="0" dy="1.2em">SAI</tspan>
+</text>
+</g>
+<g transform="translate(196, 140)" class="key keypos-25">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">RGB</tspan><tspan x="0" dy="1.2em">HUI</tspan>
+</text>
+</g>
+<g transform="translate(252, 140)" class="key keypos-26">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">RGB</tspan><tspan x="0" dy="1.2em">BRI</tspan>
+</text>
+</g>
+<g transform="translate(308, 140)" class="key keypos-27">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">RGB</tspan><tspan x="0" dy="1.2em">TOG</tspan>
+</text>
+</g>
+<g transform="translate(700, 140)" class="key keypos-28">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(756, 140)" class="key keypos-29">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(812, 140)" class="key keypos-30">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(868, 140)" class="key keypos-31">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(924, 168)" class="key keypos-32">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(980, 168)" class="key keypos-33">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(28, 224)" class="key keypos-34">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Boot</text>
+</g>
+<g transform="translate(84, 224)" class="key keypos-35">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">RGB</tspan><tspan x="0" dy="1.2em">SPD</tspan>
+</text>
+</g>
+<g transform="translate(140, 196)" class="key keypos-36">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">RGB</tspan><tspan x="0" dy="1.2em">SAD</tspan>
+</text>
+</g>
+<g transform="translate(196, 196)" class="key keypos-37">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">RGB</tspan><tspan x="0" dy="1.2em">HUD</tspan>
+</text>
+</g>
+<g transform="translate(252, 196)" class="key keypos-38">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">RGB</tspan><tspan x="0" dy="1.2em">BRD</tspan>
+</text>
+</g>
+<g transform="translate(308, 196)" class="key keypos-39">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">RGB</tspan><tspan x="0" dy="1.2em">EFF</tspan>
+</text>
+</g>
+<g transform="translate(700, 196)" class="key keypos-40">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(756, 196)" class="key keypos-41">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(812, 196)" class="key keypos-42">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(868, 196)" class="key keypos-43">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(924, 224)" class="key keypos-44">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(980, 224)" class="key keypos-45">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Boot</text>
+</g>
+<g transform="translate(28, 280)" class="key keypos-46">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Reset</text>
+</g>
+<g transform="translate(84, 280)" class="key keypos-47">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(140, 252)" class="key keypos-48">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(196, 252)" class="key keypos-49">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(252, 252)" class="key keypos-50">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(308, 252)" class="key keypos-51">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(371, 312) rotate(30.0)" class="key info keypos-52">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
+<use href="#mdi:bluetooth" xlink:href="#mdi:bluetooth" x="-7" y="-7" height="14" width="14.0" class="key info tap glyph mdi:bluetooth"/>
+<text x="0" y="-24" class="key info shifted">2</text>
+</g>
+<g transform="translate(420, 350) rotate(45.0)" class="key info keypos-53">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
+<use href="#mdi:bluetooth" xlink:href="#mdi:bluetooth" x="-7" y="-7" height="14" width="14.0" class="key info tap glyph mdi:bluetooth"/>
+<text x="0" y="-24" class="key info shifted">3</text>
+</g>
+<g transform="translate(458, 399) rotate(60.0)" class="key keypos-54">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(550, 399) rotate(-60.0)" class="key keypos-55">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(588, 350) rotate(-45.0)" class="key keypos-56">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(637, 312) rotate(-30.0)" class="key keypos-57">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(700, 252)" class="key keypos-58">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(756, 252)" class="key keypos-59">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(812, 252)" class="key keypos-60">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(868, 252)" class="key keypos-61">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(924, 280)" class="key keypos-62">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(980, 280)" class="key keypos-63">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Reset</text>
+</g>
+<g transform="translate(28, 336)" class="key keypos-64">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(84, 336)" class="key keypos-65">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(140, 308)" class="key keypos-66">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(196, 308)" class="key keypos-67">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(252, 308)" class="key keypos-68">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(314, 347) rotate(20.0)" class="key info keypos-69">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
+<use href="#mdi:bluetooth" xlink:href="#mdi:bluetooth" x="-7" y="-7" height="14" width="14.0" class="key info tap glyph mdi:bluetooth"/>
+<text x="0" y="-24" class="key info shifted">0</text>
+</g>
+<g transform="translate(369, 379) rotate(40.0)" class="key info keypos-70">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
+<use href="#mdi:bluetooth" xlink:href="#mdi:bluetooth" x="-7" y="-7" height="14" width="14.0" class="key info tap glyph mdi:bluetooth"/>
+<text x="0" y="-24" class="key info shifted">1</text>
+</g>
+<g transform="translate(410, 427) rotate(60.0)" class="key keypos-71">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:usb" xlink:href="#mdi:usb" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:usb"/>
+</g>
+<g transform="translate(598, 427) rotate(-60.0)" class="key keypos-72">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(639, 379) rotate(-40.0)" class="key keypos-73">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(694, 347) rotate(-20.0)" class="key keypos-74">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(756, 308)" class="key keypos-75">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(812, 308)" class="key keypos-76">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(868, 308)" class="key keypos-77">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(924, 336)" class="key keypos-78">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(980, 336)" class="key keypos-79">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+</g>
+</g>
+</svg>

--- a/img/glove80_navigation.svg
+++ b/img/glove80_navigation.svg
@@ -1,0 +1,649 @@
+<svg width="1068" height="577" viewBox="0 0 1068 577" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>/* start glyphs */
+<svg id="mdi:apple-keyboard-caps">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-apple-keyboard-caps" viewBox="0 0 24 24"><path d="M15,14V8H17.17L12,2.83L6.83,8H9V14H15M12,0L22,10H17V16H7V10H2L12,0M7,18H17V24H7V18M15,20H9V22H15V20Z" /></svg>
+</svg>
+<svg id="mdi:apple-keyboard-shift">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-apple-keyboard-shift" viewBox="0 0 24 24"><path d="M15,18V12H17.17L12,6.83L6.83,12H9V18H15M12,4L22,14H17V20H7V14H2L12,4Z" /></svg>
+</svg>
+<svg id="mdi:arrow-down-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-down-bold" viewBox="0 0 24 24"><path d="M9,4H15V12H19.84L12,19.84L4.16,12H9V4Z" /></svg>
+</svg>
+<svg id="mdi:arrow-left-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-left-bold" viewBox="0 0 24 24"><path d="M20,9V15H12V19.84L4.16,12L12,4.16V9H20Z" /></svg>
+</svg>
+<svg id="mdi:arrow-right-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-right-bold" viewBox="0 0 24 24"><path d="M4,15V9H12V4.16L19.84,12L12,19.84V15H4Z" /></svg>
+</svg>
+<svg id="mdi:arrow-up-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-up-bold" viewBox="0 0 24 24"><path d="M15,20H9V12H4.16L12,4.16L19.84,12H15V20Z" /></svg>
+</svg>
+<svg id="mdi:backspace">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-backspace" viewBox="0 0 24 24"><path d="M22,3H7C6.31,3 5.77,3.35 5.41,3.88L0,12L5.41,20.11C5.77,20.64 6.31,21 7,21H22A2,2 0 0,0 24,19V5A2,2 0 0,0 22,3M19,15.59L17.59,17L14,13.41L10.41,17L9,15.59L12.59,12L9,8.41L10.41,7L14,10.59L17.59,7L19,8.41L15.41,12" /></svg>
+</svg>
+<svg id="mdi:backspace-reverse-outline">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-backspace-reverse-outline" viewBox="0 0 24 24"><path d="M5,15.59L6.41,17L10,13.41L13.59,17L15,15.59L11.41,12L15,8.41L13.59,7L10,10.59L6.41,7L5,8.41L8.59,12L5,15.59M2,3A2,2 0 0,0 0,5V19A2,2 0 0,0 2,21H17C17.69,21 18.23,20.64 18.59,20.11L24,12L18.59,3.88C18.23,3.35 17.69,3 17,3H2M2,5H17L21.72,12L17,19H2V5Z" /></svg>
+</svg>
+<svg id="mdi:bluetooth">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-bluetooth" viewBox="0 0 24 24"><path d="M14.88,16.29L13,18.17V14.41M13,5.83L14.88,7.71L13,9.58M17.71,7.71L12,2H11V9.58L6.41,5L5,6.41L10.59,12L5,17.58L6.41,19L11,14.41V22H12L17.71,16.29L13.41,12L17.71,7.71Z" /></svg>
+</svg>
+<svg id="mdi:bluetooth-off">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-bluetooth-off" viewBox="0 0 24 24"><path d="M13,5.83L14.88,7.71L13.28,9.31L14.69,10.72L17.71,7.7L12,2H11V7.03L13,9.03M5.41,4L4,5.41L10.59,12L5,17.59L6.41,19L11,14.41V22H12L16.29,17.71L18.59,20L20,18.59M13,18.17V14.41L14.88,16.29" /></svg>
+</svg>
+<svg id="mdi:chevron-double-left">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-chevron-double-left" viewBox="0 0 24 24"><path d="M18.41,7.41L17,6L11,12L17,18L18.41,16.59L13.83,12L18.41,7.41M12.41,7.41L11,6L5,12L11,18L12.41,16.59L7.83,12L12.41,7.41Z" /></svg>
+</svg>
+<svg id="mdi:chevron-double-right">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-chevron-double-right" viewBox="0 0 24 24"><path d="M5.59,7.41L7,6L13,12L7,18L5.59,16.59L10.17,12L5.59,7.41M11.59,7.41L13,6L19,12L13,18L11.59,16.59L16.17,12L11.59,7.41Z" /></svg>
+</svg>
+<svg id="mdi:chevron-down">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-chevron-down" viewBox="0 0 24 24"><path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" /></svg>
+</svg>
+<svg id="mdi:controller">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-controller" viewBox="0 0 24 24"><path d="M7.97,16L5,19C4.67,19.3 4.23,19.5 3.75,19.5A1.75,1.75 0 0,1 2,17.75V17.5L3,10.12C3.21,7.81 5.14,6 7.5,6H16.5C18.86,6 20.79,7.81 21,10.12L22,17.5V17.75A1.75,1.75 0 0,1 20.25,19.5C19.77,19.5 19.33,19.3 19,19L16.03,16H7.97M7,8V10H5V11H7V13H8V11H10V10H8V8H7M16.5,8A0.75,0.75 0 0,0 15.75,8.75A0.75,0.75 0 0,0 16.5,9.5A0.75,0.75 0 0,0 17.25,8.75A0.75,0.75 0 0,0 16.5,8M14.75,9.75A0.75,0.75 0 0,0 14,10.5A0.75,0.75 0 0,0 14.75,11.25A0.75,0.75 0 0,0 15.5,10.5A0.75,0.75 0 0,0 14.75,9.75M18.25,9.75A0.75,0.75 0 0,0 17.5,10.5A0.75,0.75 0 0,0 18.25,11.25A0.75,0.75 0 0,0 19,10.5A0.75,0.75 0 0,0 18.25,9.75M16.5,11.5A0.75,0.75 0 0,0 15.75,12.25A0.75,0.75 0 0,0 16.5,13A0.75,0.75 0 0,0 17.25,12.25A0.75,0.75 0 0,0 16.5,11.5Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-outline">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-outline" viewBox="0 0 24 24"><path d="M4,5A2,2 0 0,0 2,7V17A2,2 0 0,0 4,19H20A2,2 0 0,0 22,17V7A2,2 0 0,0 20,5H4M4,7H20V17H4V7M5,8V10H7V8H5M8,8V10H10V8H8M11,8V10H13V8H11M14,8V10H16V8H14M17,8V10H19V8H17M5,11V13H7V11H5M8,11V13H10V11H8M11,11V13H13V11H11M14,11V13H16V11H14M17,11V13H19V11H17M8,14V16H16V14H8Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-return">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-return" viewBox="0 0 24 24"><path d="M19,7V11H5.83L9.41,7.41L8,6L2,12L8,18L9.41,16.58L5.83,13H21V7H19Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-space">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-space" viewBox="0 0 24 24"><path d="M3 15H5V19H19V15H21V19C21 20.1 20.1 21 19 21H5C3.9 21 3 20.1 3 19V15Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-tab">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-tab" viewBox="0 0 24 24"><path d="M20,18H22V6H20M11.59,7.41L15.17,11H1V13H15.17L11.59,16.58L13,18L19,12L13,6L11.59,7.41Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-tab-reverse">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-tab-reverse" viewBox="0 0 24 24"><path d="M4 6H2V18H4M11 6L5 12L11 18L12.41 16.58L8.83 13H23V11H8.83L12.41 7.41L11 6Z" /></svg>
+</svg>
+<svg id="mdi:monitor-dashboard">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-monitor-dashboard" viewBox="0 0 24 24"><path d="M21,16V4H3V16H21M21,2A2,2 0 0,1 23,4V16A2,2 0 0,1 21,18H14V20H16V22H8V20H10V18H3C1.89,18 1,17.1 1,16V4C1,2.89 1.89,2 3,2H21M5,6H14V11H5V6M15,6H19V8H15V6M19,9V14H15V9H19M5,12H9V14H5V12M10,12H14V14H10V12Z" /></svg>
+</svg>
+<svg id="mdi:play-pause">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-play-pause" viewBox="0 0 24 24"><path d="M3,5V19L11,12M13,19H16V5H13M18,5V19H21V5" /></svg>
+</svg>
+<svg id="mdi:skip-next">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-skip-next" viewBox="0 0 24 24"><path d="M16,18H18V6H16M6,18L14.5,12L6,6V18Z" /></svg>
+</svg>
+<svg id="mdi:skip-previous">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-skip-previous" viewBox="0 0 24 24"><path d="M6,18V6H8V18H6M9.5,12L18,6V18L9.5,12Z" /></svg>
+</svg>
+<svg id="mdi:usb">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-usb" viewBox="0 0 24 24"><path d="M15,7V11H16V13H13V5H15L12,1L9,5H11V13H8V10.93C8.7,10.56 9.2,9.85 9.2,9C9.2,7.78 8.21,6.8 7,6.8C5.78,6.8 4.8,7.78 4.8,9C4.8,9.85 5.3,10.56 6,10.93V13A2,2 0 0,0 8,15H11V18.05C10.29,18.41 9.8,19.15 9.8,20A2.2,2.2 0 0,0 12,22.2A2.2,2.2 0 0,0 14.2,20C14.2,19.15 13.71,18.41 13,18.05V15H16A2,2 0 0,0 18,13V11H19V7H15Z" /></svg>
+</svg>
+<svg id="mdi:volume-high">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-volume-high" viewBox="0 0 24 24"><path d="M14,3.23V5.29C16.89,6.15 19,8.83 19,12C19,15.17 16.89,17.84 14,18.7V20.77C18,19.86 21,16.28 21,12C21,7.72 18,4.14 14,3.23M16.5,12C16.5,10.23 15.5,8.71 14,7.97V16C15.5,15.29 16.5,13.76 16.5,12M3,9V15H7L12,20V4L7,9H3Z" /></svg>
+</svg>
+<svg id="mdi:volume-low">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-volume-low" viewBox="0 0 24 24"><path d="M7,9V15H11L16,20V4L11,9H7Z" /></svg>
+</svg>
+<svg id="mdi:volume-off">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-volume-off" viewBox="0 0 24 24"><path d="M12,4L9.91,6.09L12,8.18M4.27,3L3,4.27L7.73,9H3V15H7L12,20V13.27L16.25,17.53C15.58,18.04 14.83,18.46 14,18.7V20.77C15.38,20.45 16.63,19.82 17.68,18.96L19.73,21L21,19.73L12,10.73M19,12C19,12.94 18.8,13.82 18.46,14.64L19.97,16.15C20.62,14.91 21,13.5 21,12C21,7.72 18,4.14 14,3.23V5.29C16.89,6.15 19,8.83 19,12M16.5,12C16.5,10.23 15.5,8.71 14,7.97V10.18L16.45,12.63C16.5,12.43 16.5,12.21 16.5,12Z" /></svg>
+</svg>
+<svg id="moergo">
+<svg xml:space="preserve" viewBox="0 0 512 172">
+<path d="m60.09 80.108-.073-4.3-2.778-.046a288.998 288.998 0 0 1-3.245-.066l-.466-.02.07-9.061.07-9.062 1.777-.871c.978-.479 2.75-1.116 3.936-1.416l2.158-.546 1.938.098 1.937.098.741.549c.959.71 1.857 2.04 2.192 3.247l.266.957.002 12.37.001 12.369h18.786V75.94l-2.977-.004-2.976-.004-.335-.212-.334-.212.07-8.97.07-8.97 1.058-.598c.582-.329 1.951-.91 3.043-1.29l1.984-.691 2.513-.128 2.514-.127 1.188.615 1.189.615.578.87c.317.478.705 1.466.862 2.196l.284 1.326v24.052h18.785v-8.45l-3.24-.075-3.242-.074-.163-10.451-.163-10.451-.412-1.755c-.227-.965-.712-2.347-1.08-3.07l-.666-1.317-1.367-1.23-1.367-1.228-1.227-.55c-.676-.303-2.002-.717-2.948-.921l-1.72-.37-2.249-.004c-5.224-.006-8.928 1.154-15.272 4.78l-1.118.638-.767-.926c-.421-.51-1.437-1.388-2.257-1.952l-1.491-1.026-1.784-.654-1.784-.654-2.679-.142-2.678-.143-1.82.334c-2.344.43-5.837 1.628-7.714 2.644-.811.44-1.633.8-1.825.8h-.35v-3.176H34.749v8.731h6.62l-.068 11.012-.07 11.011-3.24-.045-3.242-.045v8.759h25.414zm307.77 35.396v-4.359l-3.903-.073-3.902-.073.035-4.101.035-4.101.462-1.853c.255-1.018.814-2.551 1.243-3.406l.78-1.555 1.203-1.287 1.203-1.286 1.393-.682 1.394-.681 2.079-.37c1.143-.205 2.766-.376 3.605-.38l1.527-.01-.071-5.754-.072-5.755-1.984.057c-2.584.073-4.265.478-6.216 1.496l-1.586.828-1.752 1.72-1.751 1.72-1.028 2.175-1.028 2.176-.331.007-.33.007V80.44h-17.994v8.466h6.88v22.225h-7.408v4.189c0 2.304.08 4.269.177 4.366l.176.176h27.164zm90.354-36.19-2.91.152-2.91.152-1.978.56c-1.087.308-2.884 1.032-3.992 1.609l-2.015 1.048-1.74 1.435-1.74 1.435-1.213 1.7c-2.198 3.08-3.398 6.55-3.74 10.81l-.178 2.2.3 2.459.301 2.459.63 1.98.628 1.98 1.085 1.827 1.085 1.826 1.653 1.634c4.082 4.035 8.828 5.94 15.046 6.043l2.016.033 2.327-.406 2.327-.406 1.743-.69c.959-.38 2.576-1.226 3.595-1.879l1.852-1.187 1.772-1.802 1.773-1.801 1.18-2.463 1.181-2.463.471-1.852.472-1.852.008-3.704.008-3.705-.35-1.587c-.52-2.36-1.549-4.81-2.85-6.788l-1.16-1.76-1.59-1.473c-2.927-2.71-6.842-4.546-11.12-5.216zm-3.213 9.327h3.301l1.28.546a8.732 8.732 0 0 1 .803.395 7.563 7.563 0 0 1 .96.64 6.99 6.99 0 0 1 1.385 1.453 7.746 7.746 0 0 1 .482.76 8.846 8.846 0 0 1 .419.847 10.375 10.375 0 0 1 .356.937 12.694 12.694 0 0 1 .297 1.029 16.376 16.376 0 0 1 .24 1.126 20.138 20.138 0 0 1 .181 1.224l.278 2.288-.27 2.375a31.867 31.867 0 0 1-.136 1.031 21.21 21.21 0 0 1-.162.925 15.296 15.296 0 0 1-.193.834 11.573 11.573 0 0 1-.23.76 9.573 9.573 0 0 1-.429 1.032 8.657 8.657 0 0 1-.542.952 10.276 10.276 0 0 1-.433.616l-.95 1.255-1.447.73-1.448.73-1.455.119a9.456 9.456 0 0 1-.638.03c-.11.002-.222.002-.332.002a11.503 11.503 0 0 1-.937-.045 5.823 5.823 0 0 1-.258-.03 3.177 3.177 0 0 1-.215-.039h-.001a8.305 8.305 0 0 1-1.082-.314 7.362 7.362 0 0 1-.746-.327 6.734 6.734 0 0 1-1.526-1.076 6.94 6.94 0 0 1-.74-.815 7.83 7.83 0 0 1-.494-.709 9.102 9.102 0 0 1-.443-.793 10.732 10.732 0 0 1-.392-.88 13.103 13.103 0 0 1-.343-.966 15.588 15.588 0 0 1-.202-.692l-.41-1.53.004-2.91.003-2.91.273-1.42a11.718 11.718 0 0 1 .274-1.062 18.563 18.563 0 0 1 .707-1.932l.706-1.573 1.046-.895 1.045-.895 1.207-.411zM132.263 11.697c-.034.046-2.106 11.691-4.604 25.88-2.498 14.188-5.55 31.51-6.78 38.493l-2.236 12.697.188.168c.104.093 14.892 2.745 32.864 5.894l32.676 5.726 2.514.825c1.382.453 3.96 1.517 5.727 2.363l3.214 1.539 2.607 1.766c5.134 3.477 9.088 7.32 12.861 12.496l1.6 2.196.291-.117c.16-.064 5.886-3.578 12.726-7.809 6.84-4.23 13.297-8.202 14.35-8.826 1.054-.623 1.917-1.227 1.919-1.342.006-.405-3.296-5.123-5.728-8.184l-2.463-3.1-3.378-3.386c-6.352-6.369-13.625-11.71-21.146-15.528-1.333-.677-2.54-1.375-2.685-1.552l-.261-.32 3.932-22.225c2.163-12.224 3.937-22.464 3.942-22.755l.008-.529-3.373-.595c-3.298-.583-37.653-6.632-64.983-11.443-7.545-1.328-13.747-2.378-13.782-2.332Zm36.233 30.314 2.35.444a24.764 24.764 0 0 1 2.44.592 23.266 23.266 0 0 1 2.777 1.03 22.678 22.678 0 0 1 2.19 1.123l1.554.907 1.945 1.848 1.945 1.848 1.024 1.626a20.183 20.183 0 0 1 .697 1.224 29.839 29.839 0 0 1 .695 1.405 21.308 21.308 0 0 1 .367.846l.737 1.85.392 2.251.391 2.252-.133 3.704-.133 3.704-.574 1.977a12.6 12.6 0 0 1-.137.439 19.653 19.653 0 0 1-.364 1.012 30.436 30.436 0 0 1-.905 2.107c-.076.158-.151.308-.224.448l-1.055 2.028-1.468 1.623a23.44 23.44 0 0 1-1.64 1.64 22.31 22.31 0 0 1-2.387 1.874 21.434 21.434 0 0 1-3.978 2.124 21.751 21.751 0 0 1-2.154.743l-1.97.568-3.837.108-3.836.108-2.25-.5a24.587 24.587 0 0 1-2.104-.565 23.215 23.215 0 0 1-1.993-.737 22.27 22.27 0 0 1-2.473-1.238 21.003 21.003 0 0 1-2.243-1.512 20.136 20.136 0 0 1-2.452-2.253 19.478 19.478 0 0 1-4.082-6.862 20.427 20.427 0 0 1-.215-.655l-.541-1.755-.293-2.61-.293-2.61.16-2.116a28.936 28.936 0 0 1 .326-2.643 25.64 25.64 0 0 1 .56-2.485 22.955 22.955 0 0 1 .793-2.32 20.977 20.977 0 0 1 .654-1.452 19.989 19.989 0 0 1 1.166-2.032 19.022 19.022 0 0 1 1.893-2.424 18.685 18.685 0 0 1 2.268-2.086 19.407 19.407 0 0 1 1.94-1.334 20.624 20.624 0 0 1 2.14-1.13 22.523 22.523 0 0 1 2.333-.917c.27-.09.544-.176.82-.257l2.298-.68 3.44-.14zm.595 31.233 1.124-.524.866-1.012.866-1.012.458-1.28c.252-.704.584-2.287.738-3.518l.278-2.238-.18-1.73c-.1-.953-.402-2.45-.67-3.33l-.49-1.599-.96-1.122-.962-1.123-1.029-.525c-.566-.288-1.554-.597-2.195-.684l-1.166-.16-1.387.332-1.387.333-1.039.939c-1.296 1.171-1.992 2.515-2.47 4.773l-.373 1.757-.005 2.147c-.002 1.18.114 2.788.258 3.572l.262 1.425.862 1.709.863 1.709 1.058.741 1.058.742 1.19.228a7.103 7.103 0 0 0 4.432-.55zm232.503 6.57-2.513.004-2.514.004-1.587.465c-.873.256-2.382.88-3.352 1.388l-1.765.924-1.686 1.632c-2.91 2.818-4.732 6.224-5.647 10.554l-.406 1.927v6.614l.393 1.866c1.764 8.345 7.056 13.98 14.045 14.951l1.93.269 1.799-.288 1.8-.287 1.868-.78 1.869-.779 2.313-1.738 2.314-1.737.3.186.303.186-.182 3.099c-.418 7.15-2.43 9.735-8.29 10.646l-1.955.304-2.253-.326-2.254-.326-1.762-.663c-.97-.365-2.146-.89-2.614-1.166l-.85-.501-2.436 3.359c-1.34 1.847-2.68 3.633-2.979 3.968l-.544.61.39.269c.215.148 1.224.677 2.244 1.176l1.855.905 2.575.654c4.317 1.095 9.784 1.447 14.354.924v-.001c3.285-.376 5.177-.9 7.805-2.159l2.249-1.077 1.765-1.792 1.764-1.793.937-1.947c.516-1.072 1.2-2.957 1.52-4.19l.584-2.244.109-16.999.109-17h6.573V80.44h-18.785v4.498h-.381c-.21 0-.987-.58-1.726-1.29l-1.346-1.289-1.575-.84c-.867-.462-2.204-1.034-2.97-1.272zm1.147 9.62h1.273l1.222.418 1.224.416 1.195 1.053 1.196 1.052.806 1.64.805 1.64.297 2.304.296 2.304-.306 2.053-.305 2.053-.624 1.363a6.734 6.734 0 0 1-.145.295 9.744 9.744 0 0 1-.364.643 13.175 13.175 0 0 1-.638.95 8.675 8.675 0 0 1-.212.275c-.07.085-.136.164-.2.235l-.936 1.036-1.26.63-1.26.629-1.87.084-1.87.085-1.089-.402a3.796 3.796 0 0 1-.24-.099 6.041 6.041 0 0 1-.545-.277 9.693 9.693 0 0 1-1.11-.727 5.709 5.709 0 0 1-.23-.187l-1.036-.886-.71-1.306a7.55 7.55 0 0 1-.152-.294 11.46 11.46 0 0 1-.314-.702 17.642 17.642 0 0 1-.554-1.527 9.1 9.1 0 0 1-.097-.34l-.405-1.557v-2.18a24.705 24.705 0 0 1 .04-1.42 17.962 17.962 0 0 1 .126-1.285 14.173 14.173 0 0 1 .133-.795 12.386 12.386 0 0 1 .397-1.488 11.71 11.71 0 0 1 .417-1.061c.053-.117.107-.233.163-.35l.686-1.414 1.224-1.099 1.223-1.1 1.238-.33a9.52 9.52 0 0 1 .581-.128 13.035 13.035 0 0 1 1.65-.196c.099-.004.193-.007.28-.007z"/>
+<path d="m323.296 50.381-2.655.46a9467.2 9467.2 0 0 0-16.281 2.872 14178.35 14178.35 0 0 1-18.786 3.313c-22 3.848-44.31 7.839-44.416 7.946-.07.07 1.64 10.158 3.803 22.416 2.162 12.258 3.94 22.517 3.95 22.798l.019.51-3.308 1.756c-12.508 6.64-22.784 15.792-30.58 27.239l-1.882 2.762 9.418 5.8a3575.83 3575.83 0 0 1 11.006 6.797c10.287 6.45 8.87 5.91 10.226 3.904 5.672-8.397 14.596-15.215 24.44-18.673l2.375-.834 33.04-5.812c18.171-3.197 33.084-5.857 33.138-5.91.101-.102-.429-3.156-8.654-49.813zM294.73 79.308l1.827.318c2.551.445 5.214 1.423 7.392 2.717l1.855 1.102 1.857 1.88 1.858 1.879.894 1.515c1.808 3.065 3.069 7.86 3.25 12.358l.09 2.249-14.788.068-14.786.068.138 1.523.138 1.523.613 1.306.614 1.305 1.028.998 1.028.998 1.366.646c.75.355 2.102.797 3.003.983l1.638.338 1.652-.307 1.651-.307 1.393-.705c.766-.387 2.152-1.335 3.08-2.105l1.686-1.4 5.083 1.636 5.083 1.636-1.164 1.6c-.64.88-1.924 2.28-2.853 3.113l-1.689 1.512-2.646 1.293-2.646 1.292-1.72.402c-.945.22-2.404.47-3.24.554-3.182.32-4.375.345-6.814.14l-2.513-.21-2.117-.547-2.116-.547-2.508-1.235-2.508-1.234-2.122-2.142-2.123-2.141-1-1.72c-1.715-2.952-2.566-6.473-2.57-10.626l-.002-2.292.391-2.042c1.536-8.027 7.238-14.325 14.962-16.525l1.978-.563 3.189-.152zm4.867 15.502c0-.666-.935-2.465-1.87-3.597l-.827-1-1.099-.563-1.098-.563-1.852-.12-1.853-.12-1.083.293c-.596.162-1.566.642-2.154 1.069l-1.07.775-.679 1.408c-.372.775-.756 1.736-.85 2.136l-.174.728h14.609z"/>
+</svg>
+
+</svg>
+<svg id="num-nav">
+<svg viewBox="0 0 12 9">
+  <path d="M4.124 6.925v-.436a.44.436 0 0 0-.44-.436.44.436 0 0 0 .44-.436v-.436a.586.581 0 0 0-.586-.581H2.366v.581h1.172v.581h-.586v.582h.586v.581H2.366v.581h1.172a.586.581 0 0 0 .586-.581"/>
+  <path d="M.461 4.6v.581h1.172v.581h-.586a.586.581 0 0 0-.586.582v1.162H2.22v-.581H1.047v-.581h.586a.586.581 0 0 0 .586-.582v-.58a.586.581 0 0 0-.586-.582Z"/>
+  <path d="M1.047 1.5a.586.581 0 0 0-.586.58v1.744a.586.581 0 0 0 .586.581h.586a.586.581 0 0 0 .586-.58V2.08a.586.581 0 0 0-.586-.58h-.586m0 .58h.586v1.744h-.586z"/>
+  <path d="M2.824 1.5v.58h.587v2.325h.586V1.5Z"/>
+  <path d="m5 2.318.647.414c.496-.67 1.174-1.102 2.004-1.192l-.04-.764a.371.372 0 0 1 .376-.373.375.376 0 0 1 .375.375l-.04.76c.83.096 1.505.528 2.004 1.192l.645-.414a.38.38 0 0 1 .513.137.369.369 0 0 1-.137.51l-.686.347a2.94 2.944 0 0 1 0 2.383l.685.35a.37.37 0 0 1 .138.509.377.377 0 0 1-.512.136l-.648-.414c-.495.67-1.173 1.102-2.003 1.192l.041.764a.371.372 0 0 1-.376.373.375.376 0 0 1-.376-.375l.038-.76c-.828-.096-1.504-.528-2.002-1.192l-.644.414a.38.38 0 0 1-.515-.137.369.369 0 0 1 .137-.511l.686-.346a2.94 2.944 0 0 1 0-2.383l-.685-.35a.37.37 0 0 1-.136-.51A.377.377 0 0 1 5 2.316m2.232 1.431c.156-.172.29-.285.519-.33l-.063-1.13c-.588.079-1.047.383-1.41.848l.954.612m1.317-.212c.104.06.191.132.266.212l.877-.61a2.225 2.228 0 0 0-.656-.57 1.903 1.905 0 0 0-.75-.28L8.23 3.413a1.106 1.107 0 0 1 .318.123m.436 1.304 1.01.514a2.214 2.217 0 0 0-.004-1.701l-1.016.51a1.051 1.052 0 0 1 .008.677m-.168.42a1.076 1.077 0 0 1-.595.33l.063 1.128c.588-.077 1.047-.381 1.41-.847l-.878-.611m-1.392.212c-.105-.06-.117-.132-.194-.215l-.95.614c.174.222.393.418.656.57.263.15.468.241.75.278l.059-1.123a1.147 1.148 0 0 1-.32-.123m-.438-1.305-1.008-.514a2.227 2.227 0 0 0 .002 1.701l1.016-.51a1.05 1.051 0 0 1-.008-.677z"/>
+</svg>
+
+</svg>
+</defs>/* end glyphs */
+<style>/* inherit to force styles through use tags */
+svg path {
+    fill: inherit;
+}
+
+/* font and background color specifications */
+svg.keymap {
+    font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
+    font-size: 14px;
+    font-kerning: normal;
+    text-rendering: optimizeLegibility;
+    fill: #24292e;
+}
+
+/* default key styling */
+rect.key {
+    fill: #f6f8fa;
+}
+
+rect.key, rect.combo {
+    stroke: #c9cccf;
+    stroke-width: 1;
+}
+
+/* default key side styling, only used is draw_key_sides is set */
+rect.side {
+    filter: brightness(90%);
+}
+
+/* color accent for combo boxes */
+rect.combo, rect.combo-separate {
+    fill: #cdf;
+}
+
+/* color accent for held keys */
+rect.held, rect.combo.held {
+    fill: #fdd;
+}
+
+/* color accent for ghost (optional) keys */
+rect.ghost, rect.combo.ghost {
+    stroke-dasharray: 4, 4;
+    stroke-width: 2;
+}
+
+text {
+    text-anchor: middle;
+    dominant-baseline: middle;
+}
+
+/* styling for layer labels */
+text.label {
+    font-weight: bold;
+    text-anchor: start;
+    stroke: white;
+    stroke-width: 2;
+    paint-order: stroke;
+}
+
+/* styling for combo tap, and key hold/shifted label text */
+text.combo, text.hold, text.shifted {
+    font-size: 11px;
+}
+
+text.hold {
+    text-anchor: middle;
+    dominant-baseline: auto;
+}
+
+text.shifted {
+    text-anchor: middle;
+    dominant-baseline: hanging;
+}
+
+/* styling for hold/shifted label text in combo box */
+text.combo.hold, text.combo.shifted {
+    font-size: 8px;
+}
+
+/* lighter symbol for transparent keys */
+text.trans {
+    fill: #7b7e81;
+}
+
+/* styling for combo dendrons */
+path.combo {
+    stroke-width: 1;
+    stroke: gray;
+    fill: none;
+}
+
+/* Start Tabler Icons Cleanup */
+/* cannot use height/width with glyphs */
+.icon-tabler > path {
+    fill: inherit;
+    stroke: inherit;
+    stroke-width: 2;
+}
+/* hide tabler's default box */
+.icon-tabler > path[stroke="none"][fill="none"] {
+    visibility: hidden;
+}
+/* End Tabler Icons Cleanup */
+
+/* Note, it is dumb, but SVG requires that ampersand be escaped (even in CSS!): &amp; */
+
+/* Nord color scheme */
+:root {
+    --dark1: #2e3440;
+    --dark2: #3b4252;
+    --dark3: #434c5e;
+    --dark4: #4c566a;
+   --light1: #d8dee9;
+   --light2: #e5e9f0;
+   --light3: #eceff4;
+    --blue1: #8fbcbb;
+    --blue2: #88c0d0;
+    --blue3: #81a1c1;
+    --blue4: #5e81ac;
+      --red: #bf616a;
+   --orange: #d08770;
+   --yellow: #ebcb8b;
+    --green: #a3be8c;
+   --purple: #b48ead;
+}
+
+.key rect {
+    stroke: var(--light3);
+    fill: var(--light3);
+}
+
+.tap {
+    fill: var(--dark1);
+    
+}
+
+.info {
+    &amp; .shifted, &amp; .hold {
+        fill: var(--dark1)
+    }
+}
+
+text.shifted, text.hold {
+  font-size: 8px;
+  fill: var(--blue4);
+}
+
+text.shifted {
+    dominant-baseline: hanging;
+    text-anchor: end;
+    translate: 22px 2px;
+}
+
+text.hold {
+  dominant-baseline: ideographic !important;
+  text-anchor: middle;
+}
+
+.held rect {
+    fill: var(--blue1);
+}
+
+.trans, .none, .ghost {
+    opacity: 0.8!important;
+    &amp; .tap {
+        fill: var(--blue2) !important;
+    }
+}
+
+/* Row 2,3,4 (alpha keys) */
+.keypos-23, .keypos-24, .keypos-25, .keypos-26, .keypos-27, .keypos-28, .keypos-29, .keypos-30, .keypos-31, .keypos-32,
+.keypos-35, .keypos-36, .keypos-37, .keypos-38, .keypos-39, .keypos-40, .keypos-41, .keypos-42, .keypos-43, .keypos-44,
+.keypos-47, .keypos-48, .keypos-49, .keypos-50, .keypos-51, .keypos-58, .keypos-59, .keypos-60, .keypos-61, .keypos-62
+{
+    &amp; rect {
+        fill: var(--light1);
+    }
+}
+
+/* Home keys */
+.keypos-35, .keypos-36, .keypos-37, .keypos-38, .keypos-41, .keypos-42, .keypos-43, .keypos-44
+{
+    &amp; rect {
+        stroke: var(--purple);
+    }
+}
+
+/* Thumb keys: */
+.keypos-52, .keypos-53, .keypos-54,     .keypos-55, .keypos-56, .keypos-57,
+.keypos-69, .keypos-70, .keypos-71,     .keypos-72, .keypos-73, .keypos-74
+{
+   /* TODO? */
+}
+
+/* Highlight WASD */
+.layer-Gaming {
+    &amp; .keypos-25 rect {
+        stroke: var(--purple);
+    }
+    &amp; .keypos-35 rect {
+        stroke: var(--light1);
+    }
+}
+</style>
+<g transform="translate(30, 0)" class="layer-navigation">
+<text x="0" y="28" class="label">navigation</text>
+<g transform="translate(0, 56)">
+<g transform="translate(28, 56)" class="key trans keypos-0">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 56)" class="key trans keypos-1">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(140, 28)" class="key trans keypos-2">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(196, 28)" class="key trans keypos-3">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(252, 28)" class="key trans keypos-4">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(756, 28)" class="key trans keypos-5">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(812, 28)" class="key trans keypos-6">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(868, 28)" class="key trans keypos-7">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(924, 56)" class="key trans keypos-8">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(980, 56)" class="key trans keypos-9">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 112)" class="key trans keypos-10">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 112)" class="key trans keypos-11">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(140, 84)" class="key trans keypos-12">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(196, 84)" class="key trans keypos-13">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(252, 84)" class="key trans keypos-14">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(308, 84)" class="key trans keypos-15">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(700, 84)" class="key trans keypos-16">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(756, 84)" class="key trans keypos-17">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(812, 84)" class="key trans keypos-18">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(868, 84)" class="key trans keypos-19">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(924, 112)" class="key trans keypos-20">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(980, 112)" class="key trans keypos-21">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 168)" class="key trans keypos-22">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 168)" class="key keypos-23">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">+</text>
+</g>
+<g transform="translate(140, 140)" class="key keypos-24">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">7</text>
+<text x="0" y="-24" class="key shifted">F7</text>
+</g>
+<g transform="translate(196, 140)" class="key keypos-25">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">8</text>
+<text x="0" y="-24" class="key shifted">F8</text>
+</g>
+<g transform="translate(252, 140)" class="key keypos-26">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">9</text>
+<text x="0" y="-24" class="key shifted">F9</text>
+</g>
+<g transform="translate(308, 140)" class="key keypos-27">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">*</text>
+<text x="0" y="-24" class="key shifted">F11</text>
+</g>
+<g transform="translate(700, 140)" class="key keypos-28">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">Pg</tspan><tspan x="0" dy="1.2em">Up</tspan>
+</text>
+</g>
+<g transform="translate(756, 140)" class="key keypos-29">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:chevron-double-left" xlink:href="#mdi:chevron-double-left" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:chevron-double-left"/>
+</g>
+<g transform="translate(812, 140)" class="key keypos-30">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:arrow-up-bold" xlink:href="#mdi:arrow-up-bold" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:arrow-up-bold"/>
+</g>
+<g transform="translate(868, 140)" class="key keypos-31">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:chevron-double-right" xlink:href="#mdi:chevron-double-right" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:chevron-double-right"/>
+</g>
+<g transform="translate(924, 168)" class="key keypos-32">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">Pg</tspan><tspan x="0" dy="1.2em">Down</tspan>
+</text>
+</g>
+<g transform="translate(980, 168)" class="key trans keypos-33">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 224)" class="key trans keypos-34">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 224)" class="key keypos-35">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">0</text>
+<text x="0" y="-24" class="key shifted">F10</text>
+</g>
+<g transform="translate(140, 196)" class="key keypos-36">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">4</text>
+<text x="0" y="-24" class="key shifted">F4</text>
+</g>
+<g transform="translate(196, 196)" class="key keypos-37">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">5</text>
+<text x="0" y="-24" class="key shifted">F5</text>
+</g>
+<g transform="translate(252, 196)" class="key keypos-38">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">6</text>
+<text x="0" y="-24" class="key shifted">F6</text>
+</g>
+<g transform="translate(308, 196)" class="key keypos-39">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">=</text>
+<text x="0" y="-24" class="key shifted">F12</text>
+</g>
+<g transform="translate(700, 196)" class="key keypos-40">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Home</text>
+</g>
+<g transform="translate(756, 196)" class="key keypos-41">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:arrow-left-bold" xlink:href="#mdi:arrow-left-bold" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:arrow-left-bold"/>
+</g>
+<g transform="translate(812, 196)" class="key keypos-42">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:arrow-down-bold" xlink:href="#mdi:arrow-down-bold" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:arrow-down-bold"/>
+</g>
+<g transform="translate(868, 196)" class="key keypos-43">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:arrow-right-bold" xlink:href="#mdi:arrow-right-bold" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:arrow-right-bold"/>
+</g>
+<g transform="translate(924, 224)" class="key keypos-44">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">End</text>
+</g>
+<g transform="translate(980, 224)" class="key trans keypos-45">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 280)" class="key trans keypos-46">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 280)" class="key keypos-47">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">-</text>
+</g>
+<g transform="translate(140, 252)" class="key keypos-48">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">1</text>
+<text x="0" y="-24" class="key shifted">F1</text>
+</g>
+<g transform="translate(196, 252)" class="key keypos-49">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">2</text>
+<text x="0" y="-24" class="key shifted">F2</text>
+</g>
+<g transform="translate(252, 252)" class="key keypos-50">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">3</text>
+<text x="0" y="-24" class="key shifted">F3</text>
+</g>
+<g transform="translate(308, 252)" class="key keypos-51">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">/</text>
+</g>
+<g transform="translate(371, 312) rotate(30.0)" class="key trans keypos-52">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(420, 350) rotate(45.0)" class="key info keypos-53">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
+<use href="#num-nav" xlink:href="#num-nav" x="-9" y="-7" height="14" width="18.666666666666668" class="key info tap glyph num-nav"/>
+<text x="0" y="24" class="key info hold"><tspan style="font-size: 71%">Num/Nav</tspan></text>
+</g>
+<g transform="translate(458, 399) rotate(60.0)" class="key trans keypos-54">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(550, 399) rotate(-60.0)" class="key trans keypos-55">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(588, 350) rotate(-45.0)" class="key info keypos-56">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key info"/>
+<use href="#num-nav" xlink:href="#num-nav" x="-9" y="-7" height="14" width="18.666666666666668" class="key info tap glyph num-nav"/>
+<text x="0" y="24" class="key info hold"><tspan style="font-size: 71%">Num/Nav</tspan></text>
+</g>
+<g transform="translate(637, 312) rotate(-30.0)" class="key trans keypos-57">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(700, 252)" class="key keypos-58">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:backspace-reverse-outline" xlink:href="#mdi:backspace-reverse-outline" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:backspace-reverse-outline"/>
+</g>
+<g transform="translate(756, 252)" class="key keypos-59">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:volume-low" xlink:href="#mdi:volume-low" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:volume-low"/>
+</g>
+<g transform="translate(812, 252)" class="key keypos-60">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:volume-off" xlink:href="#mdi:volume-off" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:volume-off"/>
+</g>
+<g transform="translate(868, 252)" class="key keypos-61">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:volume-high" xlink:href="#mdi:volume-high" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:volume-high"/>
+</g>
+<g transform="translate(924, 280)" class="key keypos-62">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Print</text>
+</g>
+<g transform="translate(980, 280)" class="key trans keypos-63">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 336)" class="key trans keypos-64">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 336)" class="key keypos-65">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">€</text>
+</g>
+<g transform="translate(140, 308)" class="key keypos-66">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">$</text>
+</g>
+<g transform="translate(196, 308)" class="key keypos-67">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">£</text>
+</g>
+<g transform="translate(252, 308)" class="key keypos-68">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">.</text>
+</g>
+<g transform="translate(314, 347) rotate(20.0)" class="key trans keypos-69">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(369, 379) rotate(40.0)" class="key keypos-70">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Esc</text>
+</g>
+<g transform="translate(410, 427) rotate(60.0)" class="key trans keypos-71">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(598, 427) rotate(-60.0)" class="key trans keypos-72">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(639, 379) rotate(-40.0)" class="key keypos-73">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:keyboard-return" xlink:href="#mdi:keyboard-return" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:keyboard-return"/>
+</g>
+<g transform="translate(694, 347) rotate(-20.0)" class="key trans keypos-74">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(756, 308)" class="key keypos-75">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:skip-previous" xlink:href="#mdi:skip-previous" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:skip-previous"/>
+</g>
+<g transform="translate(812, 308)" class="key keypos-76">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:play-pause" xlink:href="#mdi:play-pause" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:play-pause"/>
+</g>
+<g transform="translate(868, 308)" class="key keypos-77">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<use href="#mdi:skip-next" xlink:href="#mdi:skip-next" x="-7" y="-7" height="14" width="14.0" class="key tap glyph mdi:skip-next"/>
+</g>
+<g transform="translate(924, 336)" class="key trans keypos-78">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(980, 336)" class="key trans keypos-79">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+</g>
+</g>
+</svg>

--- a/img/glove80_qwerty.svg
+++ b/img/glove80_qwerty.svg
@@ -1,0 +1,631 @@
+<svg width="1068" height="577" viewBox="0 0 1068 577" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>/* start glyphs */
+<svg id="mdi:apple-keyboard-caps">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-apple-keyboard-caps" viewBox="0 0 24 24"><path d="M15,14V8H17.17L12,2.83L6.83,8H9V14H15M12,0L22,10H17V16H7V10H2L12,0M7,18H17V24H7V18M15,20H9V22H15V20Z" /></svg>
+</svg>
+<svg id="mdi:apple-keyboard-shift">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-apple-keyboard-shift" viewBox="0 0 24 24"><path d="M15,18V12H17.17L12,6.83L6.83,12H9V18H15M12,4L22,14H17V20H7V14H2L12,4Z" /></svg>
+</svg>
+<svg id="mdi:arrow-down-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-down-bold" viewBox="0 0 24 24"><path d="M9,4H15V12H19.84L12,19.84L4.16,12H9V4Z" /></svg>
+</svg>
+<svg id="mdi:arrow-left-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-left-bold" viewBox="0 0 24 24"><path d="M20,9V15H12V19.84L4.16,12L12,4.16V9H20Z" /></svg>
+</svg>
+<svg id="mdi:arrow-right-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-right-bold" viewBox="0 0 24 24"><path d="M4,15V9H12V4.16L19.84,12L12,19.84V15H4Z" /></svg>
+</svg>
+<svg id="mdi:arrow-up-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-up-bold" viewBox="0 0 24 24"><path d="M15,20H9V12H4.16L12,4.16L19.84,12H15V20Z" /></svg>
+</svg>
+<svg id="mdi:backspace">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-backspace" viewBox="0 0 24 24"><path d="M22,3H7C6.31,3 5.77,3.35 5.41,3.88L0,12L5.41,20.11C5.77,20.64 6.31,21 7,21H22A2,2 0 0,0 24,19V5A2,2 0 0,0 22,3M19,15.59L17.59,17L14,13.41L10.41,17L9,15.59L12.59,12L9,8.41L10.41,7L14,10.59L17.59,7L19,8.41L15.41,12" /></svg>
+</svg>
+<svg id="mdi:backspace-reverse-outline">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-backspace-reverse-outline" viewBox="0 0 24 24"><path d="M5,15.59L6.41,17L10,13.41L13.59,17L15,15.59L11.41,12L15,8.41L13.59,7L10,10.59L6.41,7L5,8.41L8.59,12L5,15.59M2,3A2,2 0 0,0 0,5V19A2,2 0 0,0 2,21H17C17.69,21 18.23,20.64 18.59,20.11L24,12L18.59,3.88C18.23,3.35 17.69,3 17,3H2M2,5H17L21.72,12L17,19H2V5Z" /></svg>
+</svg>
+<svg id="mdi:bluetooth">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-bluetooth" viewBox="0 0 24 24"><path d="M14.88,16.29L13,18.17V14.41M13,5.83L14.88,7.71L13,9.58M17.71,7.71L12,2H11V9.58L6.41,5L5,6.41L10.59,12L5,17.58L6.41,19L11,14.41V22H12L17.71,16.29L13.41,12L17.71,7.71Z" /></svg>
+</svg>
+<svg id="mdi:bluetooth-off">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-bluetooth-off" viewBox="0 0 24 24"><path d="M13,5.83L14.88,7.71L13.28,9.31L14.69,10.72L17.71,7.7L12,2H11V7.03L13,9.03M5.41,4L4,5.41L10.59,12L5,17.59L6.41,19L11,14.41V22H12L16.29,17.71L18.59,20L20,18.59M13,18.17V14.41L14.88,16.29" /></svg>
+</svg>
+<svg id="mdi:chevron-double-left">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-chevron-double-left" viewBox="0 0 24 24"><path d="M18.41,7.41L17,6L11,12L17,18L18.41,16.59L13.83,12L18.41,7.41M12.41,7.41L11,6L5,12L11,18L12.41,16.59L7.83,12L12.41,7.41Z" /></svg>
+</svg>
+<svg id="mdi:chevron-double-right">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-chevron-double-right" viewBox="0 0 24 24"><path d="M5.59,7.41L7,6L13,12L7,18L5.59,16.59L10.17,12L5.59,7.41M11.59,7.41L13,6L19,12L13,18L11.59,16.59L16.17,12L11.59,7.41Z" /></svg>
+</svg>
+<svg id="mdi:chevron-down">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-chevron-down" viewBox="0 0 24 24"><path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" /></svg>
+</svg>
+<svg id="mdi:controller">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-controller" viewBox="0 0 24 24"><path d="M7.97,16L5,19C4.67,19.3 4.23,19.5 3.75,19.5A1.75,1.75 0 0,1 2,17.75V17.5L3,10.12C3.21,7.81 5.14,6 7.5,6H16.5C18.86,6 20.79,7.81 21,10.12L22,17.5V17.75A1.75,1.75 0 0,1 20.25,19.5C19.77,19.5 19.33,19.3 19,19L16.03,16H7.97M7,8V10H5V11H7V13H8V11H10V10H8V8H7M16.5,8A0.75,0.75 0 0,0 15.75,8.75A0.75,0.75 0 0,0 16.5,9.5A0.75,0.75 0 0,0 17.25,8.75A0.75,0.75 0 0,0 16.5,8M14.75,9.75A0.75,0.75 0 0,0 14,10.5A0.75,0.75 0 0,0 14.75,11.25A0.75,0.75 0 0,0 15.5,10.5A0.75,0.75 0 0,0 14.75,9.75M18.25,9.75A0.75,0.75 0 0,0 17.5,10.5A0.75,0.75 0 0,0 18.25,11.25A0.75,0.75 0 0,0 19,10.5A0.75,0.75 0 0,0 18.25,9.75M16.5,11.5A0.75,0.75 0 0,0 15.75,12.25A0.75,0.75 0 0,0 16.5,13A0.75,0.75 0 0,0 17.25,12.25A0.75,0.75 0 0,0 16.5,11.5Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-outline">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-outline" viewBox="0 0 24 24"><path d="M4,5A2,2 0 0,0 2,7V17A2,2 0 0,0 4,19H20A2,2 0 0,0 22,17V7A2,2 0 0,0 20,5H4M4,7H20V17H4V7M5,8V10H7V8H5M8,8V10H10V8H8M11,8V10H13V8H11M14,8V10H16V8H14M17,8V10H19V8H17M5,11V13H7V11H5M8,11V13H10V11H8M11,11V13H13V11H11M14,11V13H16V11H14M17,11V13H19V11H17M8,14V16H16V14H8Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-return">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-return" viewBox="0 0 24 24"><path d="M19,7V11H5.83L9.41,7.41L8,6L2,12L8,18L9.41,16.58L5.83,13H21V7H19Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-space">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-space" viewBox="0 0 24 24"><path d="M3 15H5V19H19V15H21V19C21 20.1 20.1 21 19 21H5C3.9 21 3 20.1 3 19V15Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-tab">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-tab" viewBox="0 0 24 24"><path d="M20,18H22V6H20M11.59,7.41L15.17,11H1V13H15.17L11.59,16.58L13,18L19,12L13,6L11.59,7.41Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-tab-reverse">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-tab-reverse" viewBox="0 0 24 24"><path d="M4 6H2V18H4M11 6L5 12L11 18L12.41 16.58L8.83 13H23V11H8.83L12.41 7.41L11 6Z" /></svg>
+</svg>
+<svg id="mdi:monitor-dashboard">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-monitor-dashboard" viewBox="0 0 24 24"><path d="M21,16V4H3V16H21M21,2A2,2 0 0,1 23,4V16A2,2 0 0,1 21,18H14V20H16V22H8V20H10V18H3C1.89,18 1,17.1 1,16V4C1,2.89 1.89,2 3,2H21M5,6H14V11H5V6M15,6H19V8H15V6M19,9V14H15V9H19M5,12H9V14H5V12M10,12H14V14H10V12Z" /></svg>
+</svg>
+<svg id="mdi:play-pause">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-play-pause" viewBox="0 0 24 24"><path d="M3,5V19L11,12M13,19H16V5H13M18,5V19H21V5" /></svg>
+</svg>
+<svg id="mdi:skip-next">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-skip-next" viewBox="0 0 24 24"><path d="M16,18H18V6H16M6,18L14.5,12L6,6V18Z" /></svg>
+</svg>
+<svg id="mdi:skip-previous">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-skip-previous" viewBox="0 0 24 24"><path d="M6,18V6H8V18H6M9.5,12L18,6V18L9.5,12Z" /></svg>
+</svg>
+<svg id="mdi:usb">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-usb" viewBox="0 0 24 24"><path d="M15,7V11H16V13H13V5H15L12,1L9,5H11V13H8V10.93C8.7,10.56 9.2,9.85 9.2,9C9.2,7.78 8.21,6.8 7,6.8C5.78,6.8 4.8,7.78 4.8,9C4.8,9.85 5.3,10.56 6,10.93V13A2,2 0 0,0 8,15H11V18.05C10.29,18.41 9.8,19.15 9.8,20A2.2,2.2 0 0,0 12,22.2A2.2,2.2 0 0,0 14.2,20C14.2,19.15 13.71,18.41 13,18.05V15H16A2,2 0 0,0 18,13V11H19V7H15Z" /></svg>
+</svg>
+<svg id="mdi:volume-high">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-volume-high" viewBox="0 0 24 24"><path d="M14,3.23V5.29C16.89,6.15 19,8.83 19,12C19,15.17 16.89,17.84 14,18.7V20.77C18,19.86 21,16.28 21,12C21,7.72 18,4.14 14,3.23M16.5,12C16.5,10.23 15.5,8.71 14,7.97V16C15.5,15.29 16.5,13.76 16.5,12M3,9V15H7L12,20V4L7,9H3Z" /></svg>
+</svg>
+<svg id="mdi:volume-low">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-volume-low" viewBox="0 0 24 24"><path d="M7,9V15H11L16,20V4L11,9H7Z" /></svg>
+</svg>
+<svg id="mdi:volume-off">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-volume-off" viewBox="0 0 24 24"><path d="M12,4L9.91,6.09L12,8.18M4.27,3L3,4.27L7.73,9H3V15H7L12,20V13.27L16.25,17.53C15.58,18.04 14.83,18.46 14,18.7V20.77C15.38,20.45 16.63,19.82 17.68,18.96L19.73,21L21,19.73L12,10.73M19,12C19,12.94 18.8,13.82 18.46,14.64L19.97,16.15C20.62,14.91 21,13.5 21,12C21,7.72 18,4.14 14,3.23V5.29C16.89,6.15 19,8.83 19,12M16.5,12C16.5,10.23 15.5,8.71 14,7.97V10.18L16.45,12.63C16.5,12.43 16.5,12.21 16.5,12Z" /></svg>
+</svg>
+<svg id="moergo">
+<svg xml:space="preserve" viewBox="0 0 512 172">
+<path d="m60.09 80.108-.073-4.3-2.778-.046a288.998 288.998 0 0 1-3.245-.066l-.466-.02.07-9.061.07-9.062 1.777-.871c.978-.479 2.75-1.116 3.936-1.416l2.158-.546 1.938.098 1.937.098.741.549c.959.71 1.857 2.04 2.192 3.247l.266.957.002 12.37.001 12.369h18.786V75.94l-2.977-.004-2.976-.004-.335-.212-.334-.212.07-8.97.07-8.97 1.058-.598c.582-.329 1.951-.91 3.043-1.29l1.984-.691 2.513-.128 2.514-.127 1.188.615 1.189.615.578.87c.317.478.705 1.466.862 2.196l.284 1.326v24.052h18.785v-8.45l-3.24-.075-3.242-.074-.163-10.451-.163-10.451-.412-1.755c-.227-.965-.712-2.347-1.08-3.07l-.666-1.317-1.367-1.23-1.367-1.228-1.227-.55c-.676-.303-2.002-.717-2.948-.921l-1.72-.37-2.249-.004c-5.224-.006-8.928 1.154-15.272 4.78l-1.118.638-.767-.926c-.421-.51-1.437-1.388-2.257-1.952l-1.491-1.026-1.784-.654-1.784-.654-2.679-.142-2.678-.143-1.82.334c-2.344.43-5.837 1.628-7.714 2.644-.811.44-1.633.8-1.825.8h-.35v-3.176H34.749v8.731h6.62l-.068 11.012-.07 11.011-3.24-.045-3.242-.045v8.759h25.414zm307.77 35.396v-4.359l-3.903-.073-3.902-.073.035-4.101.035-4.101.462-1.853c.255-1.018.814-2.551 1.243-3.406l.78-1.555 1.203-1.287 1.203-1.286 1.393-.682 1.394-.681 2.079-.37c1.143-.205 2.766-.376 3.605-.38l1.527-.01-.071-5.754-.072-5.755-1.984.057c-2.584.073-4.265.478-6.216 1.496l-1.586.828-1.752 1.72-1.751 1.72-1.028 2.175-1.028 2.176-.331.007-.33.007V80.44h-17.994v8.466h6.88v22.225h-7.408v4.189c0 2.304.08 4.269.177 4.366l.176.176h27.164zm90.354-36.19-2.91.152-2.91.152-1.978.56c-1.087.308-2.884 1.032-3.992 1.609l-2.015 1.048-1.74 1.435-1.74 1.435-1.213 1.7c-2.198 3.08-3.398 6.55-3.74 10.81l-.178 2.2.3 2.459.301 2.459.63 1.98.628 1.98 1.085 1.827 1.085 1.826 1.653 1.634c4.082 4.035 8.828 5.94 15.046 6.043l2.016.033 2.327-.406 2.327-.406 1.743-.69c.959-.38 2.576-1.226 3.595-1.879l1.852-1.187 1.772-1.802 1.773-1.801 1.18-2.463 1.181-2.463.471-1.852.472-1.852.008-3.704.008-3.705-.35-1.587c-.52-2.36-1.549-4.81-2.85-6.788l-1.16-1.76-1.59-1.473c-2.927-2.71-6.842-4.546-11.12-5.216zm-3.213 9.327h3.301l1.28.546a8.732 8.732 0 0 1 .803.395 7.563 7.563 0 0 1 .96.64 6.99 6.99 0 0 1 1.385 1.453 7.746 7.746 0 0 1 .482.76 8.846 8.846 0 0 1 .419.847 10.375 10.375 0 0 1 .356.937 12.694 12.694 0 0 1 .297 1.029 16.376 16.376 0 0 1 .24 1.126 20.138 20.138 0 0 1 .181 1.224l.278 2.288-.27 2.375a31.867 31.867 0 0 1-.136 1.031 21.21 21.21 0 0 1-.162.925 15.296 15.296 0 0 1-.193.834 11.573 11.573 0 0 1-.23.76 9.573 9.573 0 0 1-.429 1.032 8.657 8.657 0 0 1-.542.952 10.276 10.276 0 0 1-.433.616l-.95 1.255-1.447.73-1.448.73-1.455.119a9.456 9.456 0 0 1-.638.03c-.11.002-.222.002-.332.002a11.503 11.503 0 0 1-.937-.045 5.823 5.823 0 0 1-.258-.03 3.177 3.177 0 0 1-.215-.039h-.001a8.305 8.305 0 0 1-1.082-.314 7.362 7.362 0 0 1-.746-.327 6.734 6.734 0 0 1-1.526-1.076 6.94 6.94 0 0 1-.74-.815 7.83 7.83 0 0 1-.494-.709 9.102 9.102 0 0 1-.443-.793 10.732 10.732 0 0 1-.392-.88 13.103 13.103 0 0 1-.343-.966 15.588 15.588 0 0 1-.202-.692l-.41-1.53.004-2.91.003-2.91.273-1.42a11.718 11.718 0 0 1 .274-1.062 18.563 18.563 0 0 1 .707-1.932l.706-1.573 1.046-.895 1.045-.895 1.207-.411zM132.263 11.697c-.034.046-2.106 11.691-4.604 25.88-2.498 14.188-5.55 31.51-6.78 38.493l-2.236 12.697.188.168c.104.093 14.892 2.745 32.864 5.894l32.676 5.726 2.514.825c1.382.453 3.96 1.517 5.727 2.363l3.214 1.539 2.607 1.766c5.134 3.477 9.088 7.32 12.861 12.496l1.6 2.196.291-.117c.16-.064 5.886-3.578 12.726-7.809 6.84-4.23 13.297-8.202 14.35-8.826 1.054-.623 1.917-1.227 1.919-1.342.006-.405-3.296-5.123-5.728-8.184l-2.463-3.1-3.378-3.386c-6.352-6.369-13.625-11.71-21.146-15.528-1.333-.677-2.54-1.375-2.685-1.552l-.261-.32 3.932-22.225c2.163-12.224 3.937-22.464 3.942-22.755l.008-.529-3.373-.595c-3.298-.583-37.653-6.632-64.983-11.443-7.545-1.328-13.747-2.378-13.782-2.332Zm36.233 30.314 2.35.444a24.764 24.764 0 0 1 2.44.592 23.266 23.266 0 0 1 2.777 1.03 22.678 22.678 0 0 1 2.19 1.123l1.554.907 1.945 1.848 1.945 1.848 1.024 1.626a20.183 20.183 0 0 1 .697 1.224 29.839 29.839 0 0 1 .695 1.405 21.308 21.308 0 0 1 .367.846l.737 1.85.392 2.251.391 2.252-.133 3.704-.133 3.704-.574 1.977a12.6 12.6 0 0 1-.137.439 19.653 19.653 0 0 1-.364 1.012 30.436 30.436 0 0 1-.905 2.107c-.076.158-.151.308-.224.448l-1.055 2.028-1.468 1.623a23.44 23.44 0 0 1-1.64 1.64 22.31 22.31 0 0 1-2.387 1.874 21.434 21.434 0 0 1-3.978 2.124 21.751 21.751 0 0 1-2.154.743l-1.97.568-3.837.108-3.836.108-2.25-.5a24.587 24.587 0 0 1-2.104-.565 23.215 23.215 0 0 1-1.993-.737 22.27 22.27 0 0 1-2.473-1.238 21.003 21.003 0 0 1-2.243-1.512 20.136 20.136 0 0 1-2.452-2.253 19.478 19.478 0 0 1-4.082-6.862 20.427 20.427 0 0 1-.215-.655l-.541-1.755-.293-2.61-.293-2.61.16-2.116a28.936 28.936 0 0 1 .326-2.643 25.64 25.64 0 0 1 .56-2.485 22.955 22.955 0 0 1 .793-2.32 20.977 20.977 0 0 1 .654-1.452 19.989 19.989 0 0 1 1.166-2.032 19.022 19.022 0 0 1 1.893-2.424 18.685 18.685 0 0 1 2.268-2.086 19.407 19.407 0 0 1 1.94-1.334 20.624 20.624 0 0 1 2.14-1.13 22.523 22.523 0 0 1 2.333-.917c.27-.09.544-.176.82-.257l2.298-.68 3.44-.14zm.595 31.233 1.124-.524.866-1.012.866-1.012.458-1.28c.252-.704.584-2.287.738-3.518l.278-2.238-.18-1.73c-.1-.953-.402-2.45-.67-3.33l-.49-1.599-.96-1.122-.962-1.123-1.029-.525c-.566-.288-1.554-.597-2.195-.684l-1.166-.16-1.387.332-1.387.333-1.039.939c-1.296 1.171-1.992 2.515-2.47 4.773l-.373 1.757-.005 2.147c-.002 1.18.114 2.788.258 3.572l.262 1.425.862 1.709.863 1.709 1.058.741 1.058.742 1.19.228a7.103 7.103 0 0 0 4.432-.55zm232.503 6.57-2.513.004-2.514.004-1.587.465c-.873.256-2.382.88-3.352 1.388l-1.765.924-1.686 1.632c-2.91 2.818-4.732 6.224-5.647 10.554l-.406 1.927v6.614l.393 1.866c1.764 8.345 7.056 13.98 14.045 14.951l1.93.269 1.799-.288 1.8-.287 1.868-.78 1.869-.779 2.313-1.738 2.314-1.737.3.186.303.186-.182 3.099c-.418 7.15-2.43 9.735-8.29 10.646l-1.955.304-2.253-.326-2.254-.326-1.762-.663c-.97-.365-2.146-.89-2.614-1.166l-.85-.501-2.436 3.359c-1.34 1.847-2.68 3.633-2.979 3.968l-.544.61.39.269c.215.148 1.224.677 2.244 1.176l1.855.905 2.575.654c4.317 1.095 9.784 1.447 14.354.924v-.001c3.285-.376 5.177-.9 7.805-2.159l2.249-1.077 1.765-1.792 1.764-1.793.937-1.947c.516-1.072 1.2-2.957 1.52-4.19l.584-2.244.109-16.999.109-17h6.573V80.44h-18.785v4.498h-.381c-.21 0-.987-.58-1.726-1.29l-1.346-1.289-1.575-.84c-.867-.462-2.204-1.034-2.97-1.272zm1.147 9.62h1.273l1.222.418 1.224.416 1.195 1.053 1.196 1.052.806 1.64.805 1.64.297 2.304.296 2.304-.306 2.053-.305 2.053-.624 1.363a6.734 6.734 0 0 1-.145.295 9.744 9.744 0 0 1-.364.643 13.175 13.175 0 0 1-.638.95 8.675 8.675 0 0 1-.212.275c-.07.085-.136.164-.2.235l-.936 1.036-1.26.63-1.26.629-1.87.084-1.87.085-1.089-.402a3.796 3.796 0 0 1-.24-.099 6.041 6.041 0 0 1-.545-.277 9.693 9.693 0 0 1-1.11-.727 5.709 5.709 0 0 1-.23-.187l-1.036-.886-.71-1.306a7.55 7.55 0 0 1-.152-.294 11.46 11.46 0 0 1-.314-.702 17.642 17.642 0 0 1-.554-1.527 9.1 9.1 0 0 1-.097-.34l-.405-1.557v-2.18a24.705 24.705 0 0 1 .04-1.42 17.962 17.962 0 0 1 .126-1.285 14.173 14.173 0 0 1 .133-.795 12.386 12.386 0 0 1 .397-1.488 11.71 11.71 0 0 1 .417-1.061c.053-.117.107-.233.163-.35l.686-1.414 1.224-1.099 1.223-1.1 1.238-.33a9.52 9.52 0 0 1 .581-.128 13.035 13.035 0 0 1 1.65-.196c.099-.004.193-.007.28-.007z"/>
+<path d="m323.296 50.381-2.655.46a9467.2 9467.2 0 0 0-16.281 2.872 14178.35 14178.35 0 0 1-18.786 3.313c-22 3.848-44.31 7.839-44.416 7.946-.07.07 1.64 10.158 3.803 22.416 2.162 12.258 3.94 22.517 3.95 22.798l.019.51-3.308 1.756c-12.508 6.64-22.784 15.792-30.58 27.239l-1.882 2.762 9.418 5.8a3575.83 3575.83 0 0 1 11.006 6.797c10.287 6.45 8.87 5.91 10.226 3.904 5.672-8.397 14.596-15.215 24.44-18.673l2.375-.834 33.04-5.812c18.171-3.197 33.084-5.857 33.138-5.91.101-.102-.429-3.156-8.654-49.813zM294.73 79.308l1.827.318c2.551.445 5.214 1.423 7.392 2.717l1.855 1.102 1.857 1.88 1.858 1.879.894 1.515c1.808 3.065 3.069 7.86 3.25 12.358l.09 2.249-14.788.068-14.786.068.138 1.523.138 1.523.613 1.306.614 1.305 1.028.998 1.028.998 1.366.646c.75.355 2.102.797 3.003.983l1.638.338 1.652-.307 1.651-.307 1.393-.705c.766-.387 2.152-1.335 3.08-2.105l1.686-1.4 5.083 1.636 5.083 1.636-1.164 1.6c-.64.88-1.924 2.28-2.853 3.113l-1.689 1.512-2.646 1.293-2.646 1.292-1.72.402c-.945.22-2.404.47-3.24.554-3.182.32-4.375.345-6.814.14l-2.513-.21-2.117-.547-2.116-.547-2.508-1.235-2.508-1.234-2.122-2.142-2.123-2.141-1-1.72c-1.715-2.952-2.566-6.473-2.57-10.626l-.002-2.292.391-2.042c1.536-8.027 7.238-14.325 14.962-16.525l1.978-.563 3.189-.152zm4.867 15.502c0-.666-.935-2.465-1.87-3.597l-.827-1-1.099-.563-1.098-.563-1.852-.12-1.853-.12-1.083.293c-.596.162-1.566.642-2.154 1.069l-1.07.775-.679 1.408c-.372.775-.756 1.736-.85 2.136l-.174.728h14.609z"/>
+</svg>
+
+</svg>
+<svg id="num-nav">
+<svg viewBox="0 0 12 9">
+  <path d="M4.124 6.925v-.436a.44.436 0 0 0-.44-.436.44.436 0 0 0 .44-.436v-.436a.586.581 0 0 0-.586-.581H2.366v.581h1.172v.581h-.586v.582h.586v.581H2.366v.581h1.172a.586.581 0 0 0 .586-.581"/>
+  <path d="M.461 4.6v.581h1.172v.581h-.586a.586.581 0 0 0-.586.582v1.162H2.22v-.581H1.047v-.581h.586a.586.581 0 0 0 .586-.582v-.58a.586.581 0 0 0-.586-.582Z"/>
+  <path d="M1.047 1.5a.586.581 0 0 0-.586.58v1.744a.586.581 0 0 0 .586.581h.586a.586.581 0 0 0 .586-.58V2.08a.586.581 0 0 0-.586-.58h-.586m0 .58h.586v1.744h-.586z"/>
+  <path d="M2.824 1.5v.58h.587v2.325h.586V1.5Z"/>
+  <path d="m5 2.318.647.414c.496-.67 1.174-1.102 2.004-1.192l-.04-.764a.371.372 0 0 1 .376-.373.375.376 0 0 1 .375.375l-.04.76c.83.096 1.505.528 2.004 1.192l.645-.414a.38.38 0 0 1 .513.137.369.369 0 0 1-.137.51l-.686.347a2.94 2.944 0 0 1 0 2.383l.685.35a.37.37 0 0 1 .138.509.377.377 0 0 1-.512.136l-.648-.414c-.495.67-1.173 1.102-2.003 1.192l.041.764a.371.372 0 0 1-.376.373.375.376 0 0 1-.376-.375l.038-.76c-.828-.096-1.504-.528-2.002-1.192l-.644.414a.38.38 0 0 1-.515-.137.369.369 0 0 1 .137-.511l.686-.346a2.94 2.944 0 0 1 0-2.383l-.685-.35a.37.37 0 0 1-.136-.51A.377.377 0 0 1 5 2.316m2.232 1.431c.156-.172.29-.285.519-.33l-.063-1.13c-.588.079-1.047.383-1.41.848l.954.612m1.317-.212c.104.06.191.132.266.212l.877-.61a2.225 2.228 0 0 0-.656-.57 1.903 1.905 0 0 0-.75-.28L8.23 3.413a1.106 1.107 0 0 1 .318.123m.436 1.304 1.01.514a2.214 2.217 0 0 0-.004-1.701l-1.016.51a1.051 1.052 0 0 1 .008.677m-.168.42a1.076 1.077 0 0 1-.595.33l.063 1.128c.588-.077 1.047-.381 1.41-.847l-.878-.611m-1.392.212c-.105-.06-.117-.132-.194-.215l-.95.614c.174.222.393.418.656.57.263.15.468.241.75.278l.059-1.123a1.147 1.148 0 0 1-.32-.123m-.438-1.305-1.008-.514a2.227 2.227 0 0 0 .002 1.701l1.016-.51a1.05 1.051 0 0 1-.008-.677z"/>
+</svg>
+
+</svg>
+</defs>/* end glyphs */
+<style>/* inherit to force styles through use tags */
+svg path {
+    fill: inherit;
+}
+
+/* font and background color specifications */
+svg.keymap {
+    font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
+    font-size: 14px;
+    font-kerning: normal;
+    text-rendering: optimizeLegibility;
+    fill: #24292e;
+}
+
+/* default key styling */
+rect.key {
+    fill: #f6f8fa;
+}
+
+rect.key, rect.combo {
+    stroke: #c9cccf;
+    stroke-width: 1;
+}
+
+/* default key side styling, only used is draw_key_sides is set */
+rect.side {
+    filter: brightness(90%);
+}
+
+/* color accent for combo boxes */
+rect.combo, rect.combo-separate {
+    fill: #cdf;
+}
+
+/* color accent for held keys */
+rect.held, rect.combo.held {
+    fill: #fdd;
+}
+
+/* color accent for ghost (optional) keys */
+rect.ghost, rect.combo.ghost {
+    stroke-dasharray: 4, 4;
+    stroke-width: 2;
+}
+
+text {
+    text-anchor: middle;
+    dominant-baseline: middle;
+}
+
+/* styling for layer labels */
+text.label {
+    font-weight: bold;
+    text-anchor: start;
+    stroke: white;
+    stroke-width: 2;
+    paint-order: stroke;
+}
+
+/* styling for combo tap, and key hold/shifted label text */
+text.combo, text.hold, text.shifted {
+    font-size: 11px;
+}
+
+text.hold {
+    text-anchor: middle;
+    dominant-baseline: auto;
+}
+
+text.shifted {
+    text-anchor: middle;
+    dominant-baseline: hanging;
+}
+
+/* styling for hold/shifted label text in combo box */
+text.combo.hold, text.combo.shifted {
+    font-size: 8px;
+}
+
+/* lighter symbol for transparent keys */
+text.trans {
+    fill: #7b7e81;
+}
+
+/* styling for combo dendrons */
+path.combo {
+    stroke-width: 1;
+    stroke: gray;
+    fill: none;
+}
+
+/* Start Tabler Icons Cleanup */
+/* cannot use height/width with glyphs */
+.icon-tabler > path {
+    fill: inherit;
+    stroke: inherit;
+    stroke-width: 2;
+}
+/* hide tabler's default box */
+.icon-tabler > path[stroke="none"][fill="none"] {
+    visibility: hidden;
+}
+/* End Tabler Icons Cleanup */
+
+/* Note, it is dumb, but SVG requires that ampersand be escaped (even in CSS!): &amp; */
+
+/* Nord color scheme */
+:root {
+    --dark1: #2e3440;
+    --dark2: #3b4252;
+    --dark3: #434c5e;
+    --dark4: #4c566a;
+   --light1: #d8dee9;
+   --light2: #e5e9f0;
+   --light3: #eceff4;
+    --blue1: #8fbcbb;
+    --blue2: #88c0d0;
+    --blue3: #81a1c1;
+    --blue4: #5e81ac;
+      --red: #bf616a;
+   --orange: #d08770;
+   --yellow: #ebcb8b;
+    --green: #a3be8c;
+   --purple: #b48ead;
+}
+
+.key rect {
+    stroke: var(--light3);
+    fill: var(--light3);
+}
+
+.tap {
+    fill: var(--dark1);
+    
+}
+
+.info {
+    &amp; .shifted, &amp; .hold {
+        fill: var(--dark1)
+    }
+}
+
+text.shifted, text.hold {
+  font-size: 8px;
+  fill: var(--blue4);
+}
+
+text.shifted {
+    dominant-baseline: hanging;
+    text-anchor: end;
+    translate: 22px 2px;
+}
+
+text.hold {
+  dominant-baseline: ideographic !important;
+  text-anchor: middle;
+}
+
+.held rect {
+    fill: var(--blue1);
+}
+
+.trans, .none, .ghost {
+    opacity: 0.8!important;
+    &amp; .tap {
+        fill: var(--blue2) !important;
+    }
+}
+
+/* Row 2,3,4 (alpha keys) */
+.keypos-23, .keypos-24, .keypos-25, .keypos-26, .keypos-27, .keypos-28, .keypos-29, .keypos-30, .keypos-31, .keypos-32,
+.keypos-35, .keypos-36, .keypos-37, .keypos-38, .keypos-39, .keypos-40, .keypos-41, .keypos-42, .keypos-43, .keypos-44,
+.keypos-47, .keypos-48, .keypos-49, .keypos-50, .keypos-51, .keypos-58, .keypos-59, .keypos-60, .keypos-61, .keypos-62
+{
+    &amp; rect {
+        fill: var(--light1);
+    }
+}
+
+/* Home keys */
+.keypos-35, .keypos-36, .keypos-37, .keypos-38, .keypos-41, .keypos-42, .keypos-43, .keypos-44
+{
+    &amp; rect {
+        stroke: var(--purple);
+    }
+}
+
+/* Thumb keys: */
+.keypos-52, .keypos-53, .keypos-54,     .keypos-55, .keypos-56, .keypos-57,
+.keypos-69, .keypos-70, .keypos-71,     .keypos-72, .keypos-73, .keypos-74
+{
+   /* TODO? */
+}
+
+/* Highlight WASD */
+.layer-Gaming {
+    &amp; .keypos-25 rect {
+        stroke: var(--purple);
+    }
+    &amp; .keypos-35 rect {
+        stroke: var(--light1);
+    }
+}
+</style>
+<g transform="translate(30, 0)" class="layer-qwerty">
+<text x="0" y="28" class="label">qwerty</text>
+<g transform="translate(0, 56)">
+<g transform="translate(28, 56)" class="key trans keypos-0">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 56)" class="key trans keypos-1">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(140, 28)" class="key trans keypos-2">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(196, 28)" class="key trans keypos-3">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(252, 28)" class="key trans keypos-4">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(756, 28)" class="key trans keypos-5">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(812, 28)" class="key trans keypos-6">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(868, 28)" class="key trans keypos-7">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(924, 56)" class="key trans keypos-8">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(980, 56)" class="key trans keypos-9">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 112)" class="key trans keypos-10">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 112)" class="key trans keypos-11">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(140, 84)" class="key trans keypos-12">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(196, 84)" class="key trans keypos-13">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(252, 84)" class="key trans keypos-14">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(308, 84)" class="key trans keypos-15">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(700, 84)" class="key trans keypos-16">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(756, 84)" class="key trans keypos-17">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(812, 84)" class="key trans keypos-18">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(868, 84)" class="key trans keypos-19">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(924, 112)" class="key trans keypos-20">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(980, 112)" class="key trans keypos-21">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 168)" class="key trans keypos-22">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 168)" class="key keypos-23">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Q</text>
+</g>
+<g transform="translate(140, 140)" class="key keypos-24">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">W</text>
+</g>
+<g transform="translate(196, 140)" class="key keypos-25">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">E</text>
+</g>
+<g transform="translate(252, 140)" class="key keypos-26">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">R</text>
+</g>
+<g transform="translate(308, 140)" class="key keypos-27">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">T</text>
+</g>
+<g transform="translate(700, 140)" class="key keypos-28">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Y</text>
+</g>
+<g transform="translate(756, 140)" class="key keypos-29">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">U</text>
+</g>
+<g transform="translate(812, 140)" class="key keypos-30">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">I</text>
+</g>
+<g transform="translate(868, 140)" class="key keypos-31">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">O</text>
+</g>
+<g transform="translate(924, 168)" class="key keypos-32">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">P</text>
+</g>
+<g transform="translate(980, 168)" class="key trans keypos-33">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 224)" class="key trans keypos-34">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 224)" class="key keypos-35">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">A</text>
+</g>
+<g transform="translate(140, 196)" class="key keypos-36">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">S</text>
+</g>
+<g transform="translate(196, 196)" class="key keypos-37">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">D</text>
+</g>
+<g transform="translate(252, 196)" class="key keypos-38">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">F</text>
+</g>
+<g transform="translate(308, 196)" class="key keypos-39">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">G</text>
+</g>
+<g transform="translate(700, 196)" class="key keypos-40">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">H</text>
+</g>
+<g transform="translate(756, 196)" class="key keypos-41">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">J</text>
+</g>
+<g transform="translate(812, 196)" class="key keypos-42">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">K</text>
+</g>
+<g transform="translate(868, 196)" class="key keypos-43">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">L</text>
+</g>
+<g transform="translate(924, 224)" class="key keypos-44">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">;</text>
+</g>
+<g transform="translate(980, 224)" class="key trans keypos-45">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 280)" class="key trans keypos-46">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 280)" class="key keypos-47">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Z</text>
+</g>
+<g transform="translate(140, 252)" class="key keypos-48">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">X</text>
+</g>
+<g transform="translate(196, 252)" class="key keypos-49">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">C</text>
+</g>
+<g transform="translate(252, 252)" class="key keypos-50">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">V</text>
+</g>
+<g transform="translate(308, 252)" class="key keypos-51">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">B</text>
+</g>
+<g transform="translate(371, 312) rotate(30.0)" class="key trans keypos-52">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(420, 350) rotate(45.0)" class="key trans keypos-53">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(458, 399) rotate(60.0)" class="key trans keypos-54">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(550, 399) rotate(-60.0)" class="key trans keypos-55">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(588, 350) rotate(-45.0)" class="key trans keypos-56">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(637, 312) rotate(-30.0)" class="key trans keypos-57">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(700, 252)" class="key keypos-58">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">N</text>
+</g>
+<g transform="translate(756, 252)" class="key keypos-59">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">M</text>
+</g>
+<g transform="translate(812, 252)" class="key keypos-60">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">,</text>
+</g>
+<g transform="translate(868, 252)" class="key keypos-61">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">.</text>
+</g>
+<g transform="translate(924, 280)" class="key keypos-62">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">/</text>
+</g>
+<g transform="translate(980, 280)" class="key trans keypos-63">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 336)" class="key trans keypos-64">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 336)" class="key trans keypos-65">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(140, 308)" class="key trans keypos-66">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(196, 308)" class="key trans keypos-67">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(252, 308)" class="key trans keypos-68">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(314, 347) rotate(20.0)" class="key trans keypos-69">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(369, 379) rotate(40.0)" class="key trans keypos-70">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(410, 427) rotate(60.0)" class="key trans keypos-71">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(598, 427) rotate(-60.0)" class="key trans keypos-72">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(639, 379) rotate(-40.0)" class="key trans keypos-73">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(694, 347) rotate(-20.0)" class="key trans keypos-74">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(756, 308)" class="key trans keypos-75">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(812, 308)" class="key trans keypos-76">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(868, 308)" class="key trans keypos-77">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(924, 336)" class="key trans keypos-78">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(980, 336)" class="key trans keypos-79">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+</g>
+</g>
+</svg>

--- a/img/glove80_symbols.svg
+++ b/img/glove80_symbols.svg
@@ -1,0 +1,627 @@
+<svg width="1068" height="577" viewBox="0 0 1068 577" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>/* start glyphs */
+<svg id="mdi:apple-keyboard-caps">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-apple-keyboard-caps" viewBox="0 0 24 24"><path d="M15,14V8H17.17L12,2.83L6.83,8H9V14H15M12,0L22,10H17V16H7V10H2L12,0M7,18H17V24H7V18M15,20H9V22H15V20Z" /></svg>
+</svg>
+<svg id="mdi:apple-keyboard-shift">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-apple-keyboard-shift" viewBox="0 0 24 24"><path d="M15,18V12H17.17L12,6.83L6.83,12H9V18H15M12,4L22,14H17V20H7V14H2L12,4Z" /></svg>
+</svg>
+<svg id="mdi:arrow-down-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-down-bold" viewBox="0 0 24 24"><path d="M9,4H15V12H19.84L12,19.84L4.16,12H9V4Z" /></svg>
+</svg>
+<svg id="mdi:arrow-left-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-left-bold" viewBox="0 0 24 24"><path d="M20,9V15H12V19.84L4.16,12L12,4.16V9H20Z" /></svg>
+</svg>
+<svg id="mdi:arrow-right-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-right-bold" viewBox="0 0 24 24"><path d="M4,15V9H12V4.16L19.84,12L12,19.84V15H4Z" /></svg>
+</svg>
+<svg id="mdi:arrow-up-bold">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-arrow-up-bold" viewBox="0 0 24 24"><path d="M15,20H9V12H4.16L12,4.16L19.84,12H15V20Z" /></svg>
+</svg>
+<svg id="mdi:backspace">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-backspace" viewBox="0 0 24 24"><path d="M22,3H7C6.31,3 5.77,3.35 5.41,3.88L0,12L5.41,20.11C5.77,20.64 6.31,21 7,21H22A2,2 0 0,0 24,19V5A2,2 0 0,0 22,3M19,15.59L17.59,17L14,13.41L10.41,17L9,15.59L12.59,12L9,8.41L10.41,7L14,10.59L17.59,7L19,8.41L15.41,12" /></svg>
+</svg>
+<svg id="mdi:backspace-reverse-outline">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-backspace-reverse-outline" viewBox="0 0 24 24"><path d="M5,15.59L6.41,17L10,13.41L13.59,17L15,15.59L11.41,12L15,8.41L13.59,7L10,10.59L6.41,7L5,8.41L8.59,12L5,15.59M2,3A2,2 0 0,0 0,5V19A2,2 0 0,0 2,21H17C17.69,21 18.23,20.64 18.59,20.11L24,12L18.59,3.88C18.23,3.35 17.69,3 17,3H2M2,5H17L21.72,12L17,19H2V5Z" /></svg>
+</svg>
+<svg id="mdi:bluetooth">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-bluetooth" viewBox="0 0 24 24"><path d="M14.88,16.29L13,18.17V14.41M13,5.83L14.88,7.71L13,9.58M17.71,7.71L12,2H11V9.58L6.41,5L5,6.41L10.59,12L5,17.58L6.41,19L11,14.41V22H12L17.71,16.29L13.41,12L17.71,7.71Z" /></svg>
+</svg>
+<svg id="mdi:bluetooth-off">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-bluetooth-off" viewBox="0 0 24 24"><path d="M13,5.83L14.88,7.71L13.28,9.31L14.69,10.72L17.71,7.7L12,2H11V7.03L13,9.03M5.41,4L4,5.41L10.59,12L5,17.59L6.41,19L11,14.41V22H12L16.29,17.71L18.59,20L20,18.59M13,18.17V14.41L14.88,16.29" /></svg>
+</svg>
+<svg id="mdi:chevron-double-left">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-chevron-double-left" viewBox="0 0 24 24"><path d="M18.41,7.41L17,6L11,12L17,18L18.41,16.59L13.83,12L18.41,7.41M12.41,7.41L11,6L5,12L11,18L12.41,16.59L7.83,12L12.41,7.41Z" /></svg>
+</svg>
+<svg id="mdi:chevron-double-right">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-chevron-double-right" viewBox="0 0 24 24"><path d="M5.59,7.41L7,6L13,12L7,18L5.59,16.59L10.17,12L5.59,7.41M11.59,7.41L13,6L19,12L13,18L11.59,16.59L16.17,12L11.59,7.41Z" /></svg>
+</svg>
+<svg id="mdi:chevron-down">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-chevron-down" viewBox="0 0 24 24"><path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" /></svg>
+</svg>
+<svg id="mdi:controller">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-controller" viewBox="0 0 24 24"><path d="M7.97,16L5,19C4.67,19.3 4.23,19.5 3.75,19.5A1.75,1.75 0 0,1 2,17.75V17.5L3,10.12C3.21,7.81 5.14,6 7.5,6H16.5C18.86,6 20.79,7.81 21,10.12L22,17.5V17.75A1.75,1.75 0 0,1 20.25,19.5C19.77,19.5 19.33,19.3 19,19L16.03,16H7.97M7,8V10H5V11H7V13H8V11H10V10H8V8H7M16.5,8A0.75,0.75 0 0,0 15.75,8.75A0.75,0.75 0 0,0 16.5,9.5A0.75,0.75 0 0,0 17.25,8.75A0.75,0.75 0 0,0 16.5,8M14.75,9.75A0.75,0.75 0 0,0 14,10.5A0.75,0.75 0 0,0 14.75,11.25A0.75,0.75 0 0,0 15.5,10.5A0.75,0.75 0 0,0 14.75,9.75M18.25,9.75A0.75,0.75 0 0,0 17.5,10.5A0.75,0.75 0 0,0 18.25,11.25A0.75,0.75 0 0,0 19,10.5A0.75,0.75 0 0,0 18.25,9.75M16.5,11.5A0.75,0.75 0 0,0 15.75,12.25A0.75,0.75 0 0,0 16.5,13A0.75,0.75 0 0,0 17.25,12.25A0.75,0.75 0 0,0 16.5,11.5Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-outline">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-outline" viewBox="0 0 24 24"><path d="M4,5A2,2 0 0,0 2,7V17A2,2 0 0,0 4,19H20A2,2 0 0,0 22,17V7A2,2 0 0,0 20,5H4M4,7H20V17H4V7M5,8V10H7V8H5M8,8V10H10V8H8M11,8V10H13V8H11M14,8V10H16V8H14M17,8V10H19V8H17M5,11V13H7V11H5M8,11V13H10V11H8M11,11V13H13V11H11M14,11V13H16V11H14M17,11V13H19V11H17M8,14V16H16V14H8Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-return">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-return" viewBox="0 0 24 24"><path d="M19,7V11H5.83L9.41,7.41L8,6L2,12L8,18L9.41,16.58L5.83,13H21V7H19Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-space">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-space" viewBox="0 0 24 24"><path d="M3 15H5V19H19V15H21V19C21 20.1 20.1 21 19 21H5C3.9 21 3 20.1 3 19V15Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-tab">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-tab" viewBox="0 0 24 24"><path d="M20,18H22V6H20M11.59,7.41L15.17,11H1V13H15.17L11.59,16.58L13,18L19,12L13,6L11.59,7.41Z" /></svg>
+</svg>
+<svg id="mdi:keyboard-tab-reverse">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-keyboard-tab-reverse" viewBox="0 0 24 24"><path d="M4 6H2V18H4M11 6L5 12L11 18L12.41 16.58L8.83 13H23V11H8.83L12.41 7.41L11 6Z" /></svg>
+</svg>
+<svg id="mdi:monitor-dashboard">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-monitor-dashboard" viewBox="0 0 24 24"><path d="M21,16V4H3V16H21M21,2A2,2 0 0,1 23,4V16A2,2 0 0,1 21,18H14V20H16V22H8V20H10V18H3C1.89,18 1,17.1 1,16V4C1,2.89 1.89,2 3,2H21M5,6H14V11H5V6M15,6H19V8H15V6M19,9V14H15V9H19M5,12H9V14H5V12M10,12H14V14H10V12Z" /></svg>
+</svg>
+<svg id="mdi:play-pause">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-play-pause" viewBox="0 0 24 24"><path d="M3,5V19L11,12M13,19H16V5H13M18,5V19H21V5" /></svg>
+</svg>
+<svg id="mdi:skip-next">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-skip-next" viewBox="0 0 24 24"><path d="M16,18H18V6H16M6,18L14.5,12L6,6V18Z" /></svg>
+</svg>
+<svg id="mdi:skip-previous">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-skip-previous" viewBox="0 0 24 24"><path d="M6,18V6H8V18H6M9.5,12L18,6V18L9.5,12Z" /></svg>
+</svg>
+<svg id="mdi:usb">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-usb" viewBox="0 0 24 24"><path d="M15,7V11H16V13H13V5H15L12,1L9,5H11V13H8V10.93C8.7,10.56 9.2,9.85 9.2,9C9.2,7.78 8.21,6.8 7,6.8C5.78,6.8 4.8,7.78 4.8,9C4.8,9.85 5.3,10.56 6,10.93V13A2,2 0 0,0 8,15H11V18.05C10.29,18.41 9.8,19.15 9.8,20A2.2,2.2 0 0,0 12,22.2A2.2,2.2 0 0,0 14.2,20C14.2,19.15 13.71,18.41 13,18.05V15H16A2,2 0 0,0 18,13V11H19V7H15Z" /></svg>
+</svg>
+<svg id="mdi:volume-high">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-volume-high" viewBox="0 0 24 24"><path d="M14,3.23V5.29C16.89,6.15 19,8.83 19,12C19,15.17 16.89,17.84 14,18.7V20.77C18,19.86 21,16.28 21,12C21,7.72 18,4.14 14,3.23M16.5,12C16.5,10.23 15.5,8.71 14,7.97V16C15.5,15.29 16.5,13.76 16.5,12M3,9V15H7L12,20V4L7,9H3Z" /></svg>
+</svg>
+<svg id="mdi:volume-low">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-volume-low" viewBox="0 0 24 24"><path d="M7,9V15H11L16,20V4L11,9H7Z" /></svg>
+</svg>
+<svg id="mdi:volume-off">
+<svg xmlns="http://www.w3.org/2000/svg" id="mdi-volume-off" viewBox="0 0 24 24"><path d="M12,4L9.91,6.09L12,8.18M4.27,3L3,4.27L7.73,9H3V15H7L12,20V13.27L16.25,17.53C15.58,18.04 14.83,18.46 14,18.7V20.77C15.38,20.45 16.63,19.82 17.68,18.96L19.73,21L21,19.73L12,10.73M19,12C19,12.94 18.8,13.82 18.46,14.64L19.97,16.15C20.62,14.91 21,13.5 21,12C21,7.72 18,4.14 14,3.23V5.29C16.89,6.15 19,8.83 19,12M16.5,12C16.5,10.23 15.5,8.71 14,7.97V10.18L16.45,12.63C16.5,12.43 16.5,12.21 16.5,12Z" /></svg>
+</svg>
+<svg id="moergo">
+<svg xml:space="preserve" viewBox="0 0 512 172">
+<path d="m60.09 80.108-.073-4.3-2.778-.046a288.998 288.998 0 0 1-3.245-.066l-.466-.02.07-9.061.07-9.062 1.777-.871c.978-.479 2.75-1.116 3.936-1.416l2.158-.546 1.938.098 1.937.098.741.549c.959.71 1.857 2.04 2.192 3.247l.266.957.002 12.37.001 12.369h18.786V75.94l-2.977-.004-2.976-.004-.335-.212-.334-.212.07-8.97.07-8.97 1.058-.598c.582-.329 1.951-.91 3.043-1.29l1.984-.691 2.513-.128 2.514-.127 1.188.615 1.189.615.578.87c.317.478.705 1.466.862 2.196l.284 1.326v24.052h18.785v-8.45l-3.24-.075-3.242-.074-.163-10.451-.163-10.451-.412-1.755c-.227-.965-.712-2.347-1.08-3.07l-.666-1.317-1.367-1.23-1.367-1.228-1.227-.55c-.676-.303-2.002-.717-2.948-.921l-1.72-.37-2.249-.004c-5.224-.006-8.928 1.154-15.272 4.78l-1.118.638-.767-.926c-.421-.51-1.437-1.388-2.257-1.952l-1.491-1.026-1.784-.654-1.784-.654-2.679-.142-2.678-.143-1.82.334c-2.344.43-5.837 1.628-7.714 2.644-.811.44-1.633.8-1.825.8h-.35v-3.176H34.749v8.731h6.62l-.068 11.012-.07 11.011-3.24-.045-3.242-.045v8.759h25.414zm307.77 35.396v-4.359l-3.903-.073-3.902-.073.035-4.101.035-4.101.462-1.853c.255-1.018.814-2.551 1.243-3.406l.78-1.555 1.203-1.287 1.203-1.286 1.393-.682 1.394-.681 2.079-.37c1.143-.205 2.766-.376 3.605-.38l1.527-.01-.071-5.754-.072-5.755-1.984.057c-2.584.073-4.265.478-6.216 1.496l-1.586.828-1.752 1.72-1.751 1.72-1.028 2.175-1.028 2.176-.331.007-.33.007V80.44h-17.994v8.466h6.88v22.225h-7.408v4.189c0 2.304.08 4.269.177 4.366l.176.176h27.164zm90.354-36.19-2.91.152-2.91.152-1.978.56c-1.087.308-2.884 1.032-3.992 1.609l-2.015 1.048-1.74 1.435-1.74 1.435-1.213 1.7c-2.198 3.08-3.398 6.55-3.74 10.81l-.178 2.2.3 2.459.301 2.459.63 1.98.628 1.98 1.085 1.827 1.085 1.826 1.653 1.634c4.082 4.035 8.828 5.94 15.046 6.043l2.016.033 2.327-.406 2.327-.406 1.743-.69c.959-.38 2.576-1.226 3.595-1.879l1.852-1.187 1.772-1.802 1.773-1.801 1.18-2.463 1.181-2.463.471-1.852.472-1.852.008-3.704.008-3.705-.35-1.587c-.52-2.36-1.549-4.81-2.85-6.788l-1.16-1.76-1.59-1.473c-2.927-2.71-6.842-4.546-11.12-5.216zm-3.213 9.327h3.301l1.28.546a8.732 8.732 0 0 1 .803.395 7.563 7.563 0 0 1 .96.64 6.99 6.99 0 0 1 1.385 1.453 7.746 7.746 0 0 1 .482.76 8.846 8.846 0 0 1 .419.847 10.375 10.375 0 0 1 .356.937 12.694 12.694 0 0 1 .297 1.029 16.376 16.376 0 0 1 .24 1.126 20.138 20.138 0 0 1 .181 1.224l.278 2.288-.27 2.375a31.867 31.867 0 0 1-.136 1.031 21.21 21.21 0 0 1-.162.925 15.296 15.296 0 0 1-.193.834 11.573 11.573 0 0 1-.23.76 9.573 9.573 0 0 1-.429 1.032 8.657 8.657 0 0 1-.542.952 10.276 10.276 0 0 1-.433.616l-.95 1.255-1.447.73-1.448.73-1.455.119a9.456 9.456 0 0 1-.638.03c-.11.002-.222.002-.332.002a11.503 11.503 0 0 1-.937-.045 5.823 5.823 0 0 1-.258-.03 3.177 3.177 0 0 1-.215-.039h-.001a8.305 8.305 0 0 1-1.082-.314 7.362 7.362 0 0 1-.746-.327 6.734 6.734 0 0 1-1.526-1.076 6.94 6.94 0 0 1-.74-.815 7.83 7.83 0 0 1-.494-.709 9.102 9.102 0 0 1-.443-.793 10.732 10.732 0 0 1-.392-.88 13.103 13.103 0 0 1-.343-.966 15.588 15.588 0 0 1-.202-.692l-.41-1.53.004-2.91.003-2.91.273-1.42a11.718 11.718 0 0 1 .274-1.062 18.563 18.563 0 0 1 .707-1.932l.706-1.573 1.046-.895 1.045-.895 1.207-.411zM132.263 11.697c-.034.046-2.106 11.691-4.604 25.88-2.498 14.188-5.55 31.51-6.78 38.493l-2.236 12.697.188.168c.104.093 14.892 2.745 32.864 5.894l32.676 5.726 2.514.825c1.382.453 3.96 1.517 5.727 2.363l3.214 1.539 2.607 1.766c5.134 3.477 9.088 7.32 12.861 12.496l1.6 2.196.291-.117c.16-.064 5.886-3.578 12.726-7.809 6.84-4.23 13.297-8.202 14.35-8.826 1.054-.623 1.917-1.227 1.919-1.342.006-.405-3.296-5.123-5.728-8.184l-2.463-3.1-3.378-3.386c-6.352-6.369-13.625-11.71-21.146-15.528-1.333-.677-2.54-1.375-2.685-1.552l-.261-.32 3.932-22.225c2.163-12.224 3.937-22.464 3.942-22.755l.008-.529-3.373-.595c-3.298-.583-37.653-6.632-64.983-11.443-7.545-1.328-13.747-2.378-13.782-2.332Zm36.233 30.314 2.35.444a24.764 24.764 0 0 1 2.44.592 23.266 23.266 0 0 1 2.777 1.03 22.678 22.678 0 0 1 2.19 1.123l1.554.907 1.945 1.848 1.945 1.848 1.024 1.626a20.183 20.183 0 0 1 .697 1.224 29.839 29.839 0 0 1 .695 1.405 21.308 21.308 0 0 1 .367.846l.737 1.85.392 2.251.391 2.252-.133 3.704-.133 3.704-.574 1.977a12.6 12.6 0 0 1-.137.439 19.653 19.653 0 0 1-.364 1.012 30.436 30.436 0 0 1-.905 2.107c-.076.158-.151.308-.224.448l-1.055 2.028-1.468 1.623a23.44 23.44 0 0 1-1.64 1.64 22.31 22.31 0 0 1-2.387 1.874 21.434 21.434 0 0 1-3.978 2.124 21.751 21.751 0 0 1-2.154.743l-1.97.568-3.837.108-3.836.108-2.25-.5a24.587 24.587 0 0 1-2.104-.565 23.215 23.215 0 0 1-1.993-.737 22.27 22.27 0 0 1-2.473-1.238 21.003 21.003 0 0 1-2.243-1.512 20.136 20.136 0 0 1-2.452-2.253 19.478 19.478 0 0 1-4.082-6.862 20.427 20.427 0 0 1-.215-.655l-.541-1.755-.293-2.61-.293-2.61.16-2.116a28.936 28.936 0 0 1 .326-2.643 25.64 25.64 0 0 1 .56-2.485 22.955 22.955 0 0 1 .793-2.32 20.977 20.977 0 0 1 .654-1.452 19.989 19.989 0 0 1 1.166-2.032 19.022 19.022 0 0 1 1.893-2.424 18.685 18.685 0 0 1 2.268-2.086 19.407 19.407 0 0 1 1.94-1.334 20.624 20.624 0 0 1 2.14-1.13 22.523 22.523 0 0 1 2.333-.917c.27-.09.544-.176.82-.257l2.298-.68 3.44-.14zm.595 31.233 1.124-.524.866-1.012.866-1.012.458-1.28c.252-.704.584-2.287.738-3.518l.278-2.238-.18-1.73c-.1-.953-.402-2.45-.67-3.33l-.49-1.599-.96-1.122-.962-1.123-1.029-.525c-.566-.288-1.554-.597-2.195-.684l-1.166-.16-1.387.332-1.387.333-1.039.939c-1.296 1.171-1.992 2.515-2.47 4.773l-.373 1.757-.005 2.147c-.002 1.18.114 2.788.258 3.572l.262 1.425.862 1.709.863 1.709 1.058.741 1.058.742 1.19.228a7.103 7.103 0 0 0 4.432-.55zm232.503 6.57-2.513.004-2.514.004-1.587.465c-.873.256-2.382.88-3.352 1.388l-1.765.924-1.686 1.632c-2.91 2.818-4.732 6.224-5.647 10.554l-.406 1.927v6.614l.393 1.866c1.764 8.345 7.056 13.98 14.045 14.951l1.93.269 1.799-.288 1.8-.287 1.868-.78 1.869-.779 2.313-1.738 2.314-1.737.3.186.303.186-.182 3.099c-.418 7.15-2.43 9.735-8.29 10.646l-1.955.304-2.253-.326-2.254-.326-1.762-.663c-.97-.365-2.146-.89-2.614-1.166l-.85-.501-2.436 3.359c-1.34 1.847-2.68 3.633-2.979 3.968l-.544.61.39.269c.215.148 1.224.677 2.244 1.176l1.855.905 2.575.654c4.317 1.095 9.784 1.447 14.354.924v-.001c3.285-.376 5.177-.9 7.805-2.159l2.249-1.077 1.765-1.792 1.764-1.793.937-1.947c.516-1.072 1.2-2.957 1.52-4.19l.584-2.244.109-16.999.109-17h6.573V80.44h-18.785v4.498h-.381c-.21 0-.987-.58-1.726-1.29l-1.346-1.289-1.575-.84c-.867-.462-2.204-1.034-2.97-1.272zm1.147 9.62h1.273l1.222.418 1.224.416 1.195 1.053 1.196 1.052.806 1.64.805 1.64.297 2.304.296 2.304-.306 2.053-.305 2.053-.624 1.363a6.734 6.734 0 0 1-.145.295 9.744 9.744 0 0 1-.364.643 13.175 13.175 0 0 1-.638.95 8.675 8.675 0 0 1-.212.275c-.07.085-.136.164-.2.235l-.936 1.036-1.26.63-1.26.629-1.87.084-1.87.085-1.089-.402a3.796 3.796 0 0 1-.24-.099 6.041 6.041 0 0 1-.545-.277 9.693 9.693 0 0 1-1.11-.727 5.709 5.709 0 0 1-.23-.187l-1.036-.886-.71-1.306a7.55 7.55 0 0 1-.152-.294 11.46 11.46 0 0 1-.314-.702 17.642 17.642 0 0 1-.554-1.527 9.1 9.1 0 0 1-.097-.34l-.405-1.557v-2.18a24.705 24.705 0 0 1 .04-1.42 17.962 17.962 0 0 1 .126-1.285 14.173 14.173 0 0 1 .133-.795 12.386 12.386 0 0 1 .397-1.488 11.71 11.71 0 0 1 .417-1.061c.053-.117.107-.233.163-.35l.686-1.414 1.224-1.099 1.223-1.1 1.238-.33a9.52 9.52 0 0 1 .581-.128 13.035 13.035 0 0 1 1.65-.196c.099-.004.193-.007.28-.007z"/>
+<path d="m323.296 50.381-2.655.46a9467.2 9467.2 0 0 0-16.281 2.872 14178.35 14178.35 0 0 1-18.786 3.313c-22 3.848-44.31 7.839-44.416 7.946-.07.07 1.64 10.158 3.803 22.416 2.162 12.258 3.94 22.517 3.95 22.798l.019.51-3.308 1.756c-12.508 6.64-22.784 15.792-30.58 27.239l-1.882 2.762 9.418 5.8a3575.83 3575.83 0 0 1 11.006 6.797c10.287 6.45 8.87 5.91 10.226 3.904 5.672-8.397 14.596-15.215 24.44-18.673l2.375-.834 33.04-5.812c18.171-3.197 33.084-5.857 33.138-5.91.101-.102-.429-3.156-8.654-49.813zM294.73 79.308l1.827.318c2.551.445 5.214 1.423 7.392 2.717l1.855 1.102 1.857 1.88 1.858 1.879.894 1.515c1.808 3.065 3.069 7.86 3.25 12.358l.09 2.249-14.788.068-14.786.068.138 1.523.138 1.523.613 1.306.614 1.305 1.028.998 1.028.998 1.366.646c.75.355 2.102.797 3.003.983l1.638.338 1.652-.307 1.651-.307 1.393-.705c.766-.387 2.152-1.335 3.08-2.105l1.686-1.4 5.083 1.636 5.083 1.636-1.164 1.6c-.64.88-1.924 2.28-2.853 3.113l-1.689 1.512-2.646 1.293-2.646 1.292-1.72.402c-.945.22-2.404.47-3.24.554-3.182.32-4.375.345-6.814.14l-2.513-.21-2.117-.547-2.116-.547-2.508-1.235-2.508-1.234-2.122-2.142-2.123-2.141-1-1.72c-1.715-2.952-2.566-6.473-2.57-10.626l-.002-2.292.391-2.042c1.536-8.027 7.238-14.325 14.962-16.525l1.978-.563 3.189-.152zm4.867 15.502c0-.666-.935-2.465-1.87-3.597l-.827-1-1.099-.563-1.098-.563-1.852-.12-1.853-.12-1.083.293c-.596.162-1.566.642-2.154 1.069l-1.07.775-.679 1.408c-.372.775-.756 1.736-.85 2.136l-.174.728h14.609z"/>
+</svg>
+
+</svg>
+<svg id="num-nav">
+<svg viewBox="0 0 12 9">
+  <path d="M4.124 6.925v-.436a.44.436 0 0 0-.44-.436.44.436 0 0 0 .44-.436v-.436a.586.581 0 0 0-.586-.581H2.366v.581h1.172v.581h-.586v.582h.586v.581H2.366v.581h1.172a.586.581 0 0 0 .586-.581"/>
+  <path d="M.461 4.6v.581h1.172v.581h-.586a.586.581 0 0 0-.586.582v1.162H2.22v-.581H1.047v-.581h.586a.586.581 0 0 0 .586-.582v-.58a.586.581 0 0 0-.586-.582Z"/>
+  <path d="M1.047 1.5a.586.581 0 0 0-.586.58v1.744a.586.581 0 0 0 .586.581h.586a.586.581 0 0 0 .586-.58V2.08a.586.581 0 0 0-.586-.58h-.586m0 .58h.586v1.744h-.586z"/>
+  <path d="M2.824 1.5v.58h.587v2.325h.586V1.5Z"/>
+  <path d="m5 2.318.647.414c.496-.67 1.174-1.102 2.004-1.192l-.04-.764a.371.372 0 0 1 .376-.373.375.376 0 0 1 .375.375l-.04.76c.83.096 1.505.528 2.004 1.192l.645-.414a.38.38 0 0 1 .513.137.369.369 0 0 1-.137.51l-.686.347a2.94 2.944 0 0 1 0 2.383l.685.35a.37.37 0 0 1 .138.509.377.377 0 0 1-.512.136l-.648-.414c-.495.67-1.173 1.102-2.003 1.192l.041.764a.371.372 0 0 1-.376.373.375.376 0 0 1-.376-.375l.038-.76c-.828-.096-1.504-.528-2.002-1.192l-.644.414a.38.38 0 0 1-.515-.137.369.369 0 0 1 .137-.511l.686-.346a2.94 2.944 0 0 1 0-2.383l-.685-.35a.37.37 0 0 1-.136-.51A.377.377 0 0 1 5 2.316m2.232 1.431c.156-.172.29-.285.519-.33l-.063-1.13c-.588.079-1.047.383-1.41.848l.954.612m1.317-.212c.104.06.191.132.266.212l.877-.61a2.225 2.228 0 0 0-.656-.57 1.903 1.905 0 0 0-.75-.28L8.23 3.413a1.106 1.107 0 0 1 .318.123m.436 1.304 1.01.514a2.214 2.217 0 0 0-.004-1.701l-1.016.51a1.051 1.052 0 0 1 .008.677m-.168.42a1.076 1.077 0 0 1-.595.33l.063 1.128c.588-.077 1.047-.381 1.41-.847l-.878-.611m-1.392.212c-.105-.06-.117-.132-.194-.215l-.95.614c.174.222.393.418.656.57.263.15.468.241.75.278l.059-1.123a1.147 1.148 0 0 1-.32-.123m-.438-1.305-1.008-.514a2.227 2.227 0 0 0 .002 1.701l1.016-.51a1.05 1.051 0 0 1-.008-.677z"/>
+</svg>
+
+</svg>
+</defs>/* end glyphs */
+<style>/* inherit to force styles through use tags */
+svg path {
+    fill: inherit;
+}
+
+/* font and background color specifications */
+svg.keymap {
+    font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
+    font-size: 14px;
+    font-kerning: normal;
+    text-rendering: optimizeLegibility;
+    fill: #24292e;
+}
+
+/* default key styling */
+rect.key {
+    fill: #f6f8fa;
+}
+
+rect.key, rect.combo {
+    stroke: #c9cccf;
+    stroke-width: 1;
+}
+
+/* default key side styling, only used is draw_key_sides is set */
+rect.side {
+    filter: brightness(90%);
+}
+
+/* color accent for combo boxes */
+rect.combo, rect.combo-separate {
+    fill: #cdf;
+}
+
+/* color accent for held keys */
+rect.held, rect.combo.held {
+    fill: #fdd;
+}
+
+/* color accent for ghost (optional) keys */
+rect.ghost, rect.combo.ghost {
+    stroke-dasharray: 4, 4;
+    stroke-width: 2;
+}
+
+text {
+    text-anchor: middle;
+    dominant-baseline: middle;
+}
+
+/* styling for layer labels */
+text.label {
+    font-weight: bold;
+    text-anchor: start;
+    stroke: white;
+    stroke-width: 2;
+    paint-order: stroke;
+}
+
+/* styling for combo tap, and key hold/shifted label text */
+text.combo, text.hold, text.shifted {
+    font-size: 11px;
+}
+
+text.hold {
+    text-anchor: middle;
+    dominant-baseline: auto;
+}
+
+text.shifted {
+    text-anchor: middle;
+    dominant-baseline: hanging;
+}
+
+/* styling for hold/shifted label text in combo box */
+text.combo.hold, text.combo.shifted {
+    font-size: 8px;
+}
+
+/* lighter symbol for transparent keys */
+text.trans {
+    fill: #7b7e81;
+}
+
+/* styling for combo dendrons */
+path.combo {
+    stroke-width: 1;
+    stroke: gray;
+    fill: none;
+}
+
+/* Start Tabler Icons Cleanup */
+/* cannot use height/width with glyphs */
+.icon-tabler > path {
+    fill: inherit;
+    stroke: inherit;
+    stroke-width: 2;
+}
+/* hide tabler's default box */
+.icon-tabler > path[stroke="none"][fill="none"] {
+    visibility: hidden;
+}
+/* End Tabler Icons Cleanup */
+
+/* Note, it is dumb, but SVG requires that ampersand be escaped (even in CSS!): &amp; */
+
+/* Nord color scheme */
+:root {
+    --dark1: #2e3440;
+    --dark2: #3b4252;
+    --dark3: #434c5e;
+    --dark4: #4c566a;
+   --light1: #d8dee9;
+   --light2: #e5e9f0;
+   --light3: #eceff4;
+    --blue1: #8fbcbb;
+    --blue2: #88c0d0;
+    --blue3: #81a1c1;
+    --blue4: #5e81ac;
+      --red: #bf616a;
+   --orange: #d08770;
+   --yellow: #ebcb8b;
+    --green: #a3be8c;
+   --purple: #b48ead;
+}
+
+.key rect {
+    stroke: var(--light3);
+    fill: var(--light3);
+}
+
+.tap {
+    fill: var(--dark1);
+    
+}
+
+.info {
+    &amp; .shifted, &amp; .hold {
+        fill: var(--dark1)
+    }
+}
+
+text.shifted, text.hold {
+  font-size: 8px;
+  fill: var(--blue4);
+}
+
+text.shifted {
+    dominant-baseline: hanging;
+    text-anchor: end;
+    translate: 22px 2px;
+}
+
+text.hold {
+  dominant-baseline: ideographic !important;
+  text-anchor: middle;
+}
+
+.held rect {
+    fill: var(--blue1);
+}
+
+.trans, .none, .ghost {
+    opacity: 0.8!important;
+    &amp; .tap {
+        fill: var(--blue2) !important;
+    }
+}
+
+/* Row 2,3,4 (alpha keys) */
+.keypos-23, .keypos-24, .keypos-25, .keypos-26, .keypos-27, .keypos-28, .keypos-29, .keypos-30, .keypos-31, .keypos-32,
+.keypos-35, .keypos-36, .keypos-37, .keypos-38, .keypos-39, .keypos-40, .keypos-41, .keypos-42, .keypos-43, .keypos-44,
+.keypos-47, .keypos-48, .keypos-49, .keypos-50, .keypos-51, .keypos-58, .keypos-59, .keypos-60, .keypos-61, .keypos-62
+{
+    &amp; rect {
+        fill: var(--light1);
+    }
+}
+
+/* Home keys */
+.keypos-35, .keypos-36, .keypos-37, .keypos-38, .keypos-41, .keypos-42, .keypos-43, .keypos-44
+{
+    &amp; rect {
+        stroke: var(--purple);
+    }
+}
+
+/* Thumb keys: */
+.keypos-52, .keypos-53, .keypos-54,     .keypos-55, .keypos-56, .keypos-57,
+.keypos-69, .keypos-70, .keypos-71,     .keypos-72, .keypos-73, .keypos-74
+{
+   /* TODO? */
+}
+
+/* Highlight WASD */
+.layer-Gaming {
+    &amp; .keypos-25 rect {
+        stroke: var(--purple);
+    }
+    &amp; .keypos-35 rect {
+        stroke: var(--light1);
+    }
+}
+</style>
+<g transform="translate(30, 0)" class="layer-symbols">
+<text x="0" y="28" class="label">symbols</text>
+<g transform="translate(0, 56)">
+<g transform="translate(28, 56)" class="key trans keypos-0">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 56)" class="key trans keypos-1">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(140, 28)" class="key trans keypos-2">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(196, 28)" class="key trans keypos-3">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(252, 28)" class="key trans keypos-4">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(756, 28)" class="key trans keypos-5">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(812, 28)" class="key trans keypos-6">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(868, 28)" class="key trans keypos-7">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(924, 56)" class="key trans keypos-8">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(980, 56)" class="key trans keypos-9">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 112)" class="key trans keypos-10">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 112)" class="key trans keypos-11">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(140, 84)" class="key trans keypos-12">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(196, 84)" class="key trans keypos-13">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(252, 84)" class="key trans keypos-14">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(308, 84)" class="key trans keypos-15">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(700, 84)" class="key trans keypos-16">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(756, 84)" class="key trans keypos-17">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(812, 84)" class="key trans keypos-18">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(868, 84)" class="key trans keypos-19">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(924, 112)" class="key trans keypos-20">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(980, 112)" class="key trans keypos-21">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 168)" class="key trans keypos-22">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 168)" class="key keypos-23">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">`</text>
+</g>
+<g transform="translate(140, 140)" class="key keypos-24">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">&lt;</text>
+</g>
+<g transform="translate(196, 140)" class="key keypos-25">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">&gt;</text>
+</g>
+<g transform="translate(252, 140)" class="key keypos-26">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">&quot;</text>
+</g>
+<g transform="translate(308, 140)" class="key keypos-27">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">£</text>
+</g>
+<g transform="translate(700, 140)" class="key keypos-28">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">:</text>
+</g>
+<g transform="translate(756, 140)" class="key keypos-29">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">%</text>
+</g>
+<g transform="translate(812, 140)" class="key keypos-30">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">[</text>
+</g>
+<g transform="translate(868, 140)" class="key keypos-31">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">]</text>
+</g>
+<g transform="translate(924, 168)" class="key keypos-32">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">^</text>
+</g>
+<g transform="translate(980, 168)" class="key trans keypos-33">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 224)" class="key trans keypos-34">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 224)" class="key keypos-35">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">~</text>
+</g>
+<g transform="translate(140, 196)" class="key keypos-36">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">-</text>
+</g>
+<g transform="translate(196, 196)" class="key keypos-37">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">+</text>
+</g>
+<g transform="translate(252, 196)" class="key keypos-38">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">=</text>
+</g>
+<g transform="translate(308, 196)" class="key keypos-39">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">#</text>
+</g>
+<g transform="translate(700, 196)" class="key keypos-40">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">?</text>
+</g>
+<g transform="translate(756, 196)" class="key keypos-41">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">!</text>
+</g>
+<g transform="translate(812, 196)" class="key keypos-42">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">(</text>
+</g>
+<g transform="translate(868, 196)" class="key keypos-43">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">)</text>
+</g>
+<g transform="translate(924, 224)" class="key keypos-44">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">&amp;</text>
+</g>
+<g transform="translate(980, 224)" class="key keypos-45">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">@</text>
+</g>
+<g transform="translate(28, 280)" class="key trans keypos-46">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 280)" class="key keypos-47">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">\</text>
+</g>
+<g transform="translate(140, 252)" class="key keypos-48">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">/</text>
+</g>
+<g transform="translate(196, 252)" class="key keypos-49">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">*</text>
+</g>
+<g transform="translate(252, 252)" class="key keypos-50">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">&#x27;</text>
+</g>
+<g transform="translate(308, 252)" class="key keypos-51">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">€</text>
+</g>
+<g transform="translate(371, 312) rotate(30.0)" class="key trans keypos-52">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(420, 350) rotate(45.0)" class="key keypos-53">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(458, 399) rotate(60.0)" class="key trans keypos-54">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(550, 399) rotate(-60.0)" class="key trans keypos-55">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(588, 350) rotate(-45.0)" class="key keypos-56">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+</g>
+<g transform="translate(637, 312) rotate(-30.0)" class="key trans keypos-57">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(700, 252)" class="key keypos-58">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">;</text>
+</g>
+<g transform="translate(756, 252)" class="key keypos-59">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">$</text>
+</g>
+<g transform="translate(812, 252)" class="key keypos-60">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">{</text>
+</g>
+<g transform="translate(868, 252)" class="key keypos-61">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">}</text>
+</g>
+<g transform="translate(924, 280)" class="key keypos-62">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">|</text>
+</g>
+<g transform="translate(980, 280)" class="key trans keypos-63">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(28, 336)" class="key trans keypos-64">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(84, 336)" class="key trans keypos-65">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(140, 308)" class="key trans keypos-66">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(196, 308)" class="key trans keypos-67">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(252, 308)" class="key trans keypos-68">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(314, 347) rotate(20.0)" class="key trans keypos-69">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(369, 379) rotate(40.0)" class="key held keypos-70">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key held"/>
+</g>
+<g transform="translate(410, 427) rotate(60.0)" class="key trans keypos-71">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(598, 427) rotate(-60.0)" class="key trans keypos-72">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(639, 379) rotate(-40.0)" class="key held keypos-73">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key held"/>
+</g>
+<g transform="translate(694, 347) rotate(-20.0)" class="key trans keypos-74">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(756, 308)" class="key trans keypos-75">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(812, 308)" class="key trans keypos-76">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(868, 308)" class="key trans keypos-77">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(924, 336)" class="key trans keypos-78">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+<g transform="translate(980, 336)" class="key trans keypos-79">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<use href="#mdi:chevron-down" xlink:href="#mdi:chevron-down" x="-7" y="-7" height="14" width="14.0" class="key trans tap glyph mdi:chevron-down"/>
+</g>
+</g>
+</g>
+</svg>


### PR DESCRIPTION
Refactor keymap-drawer so that is is part of the flake.

- [x] Build keymap-drawer using [poetry2nix]
- [x] Re-implement CI logic/scripts as nix builds
- [ ] Port CI to flake builds
- [ ] Remove old scripts
- [ ] Remove symlink hack-fix, needs https://github.com/caksoylar/keymap-drawer/issues/84
- [ ] Fix SVG icons (can't download in a pure env)
   - [ ] [`glyph_urls`](https://github.com/caksoylar/keymap-drawer/blob/main/CONFIGURATION.md#glyph_urls) might support `file:` URLs? If not open upstream request.
   - [ ] `use_local_cache` may need to be disabled, depending on where it writes to

[poetry2nix]: https://github.com/nix-community/poetry2nix
[devshell]: https://numtide.github.io/devshell
