### PR TITLE
Make `flash` script more interactive

### DIFF
--- a/packages/flash.nix
+++ b/packages/flash.nix
@@ -88,16 +88,26 @@
 
           # We have a winner!
           kb="''${matches[0]}"
-          echo "Found keyboard:"
+          echo "Flashing keyboard:"
           echo "$kb"
           indent < "$kb"/INFO_UF2.TXT
-          echo
 
-          # Flash by copying the firmware package
-          gum spin --title "Flashing firmware..." \
-            -- cp -Tfr "${config.packages.firmware}" "$kb" \
-            && echo "Firmaware flashed!" \
-            || echo "Error flashing firmware!"
+          # Ask before flashing...
+          if gum confirm "Are you sure?" \
+              --default="yes" \
+              --affirmative="Flash" \
+              --negative="Cancel"
+          then
+            # Flash by copying the firmware package
+            gum spin --title "Flashing firmware..." \
+              -- cp -Tfr "${config.packages.firmware}" "$kb" \
+              && echo "Firmaware flashed!" \
+              || echo "Error flashing firmware!"
+          else
+            echo "Cancelled"
+          fi
+
+          echo # blankline
         }
 
         # Run the script

--- a/packages/flash.nix
+++ b/packages/flash.nix
@@ -21,6 +21,9 @@
         # Enable nullglob so that non-matching globs have no output
         shopt -s nullglob
 
+        # Store a reference to the CLI args for use within functions
+        declare -a args=("$@")
+
         # Style
         export GUM_SPIN_SPINNER="minidot"
 
@@ -58,9 +61,19 @@
             indent < /proc/version >&2
           fi
 
+          # Check CLI args first
+          # Warn if any don't have a valid INFO_UF2
+          for disk in "''${args[@]}"; do
+            if grep -sq Glove80 "$disk"/INFO_UF2.TXT; then
+              echo "$disk"
+            else
+              echo "Not a Glove80 keyboard: $disk" >&2
+            fi
+          done
+
           # Print disks that have a matching INFO_UF2
           for disk in "''${disks[@]}"; do
-            if (grep -sq Glove80 "$disk"/INFO_UF2.TXT); then
+            if grep -sq Glove80 "$disk"/INFO_UF2.TXT; then
               echo "$disk"
             fi
           done

--- a/packages/flash.nix
+++ b/packages/flash.nix
@@ -64,64 +64,59 @@
           done
         }
 
-        flash() {
+        # Flash all keyboards found by `list_keyboards`
+        flash_keyboards() {
           declare -a matches
           readarray -t matches < <(list_keyboards)
-
-          # Assert we found exactly one keyboard
           count="''${#matches[@]}"
-          if [[ "$count" -lt 1 ]]; then
-            # No matches. Exit
-            echo "Error: No Glove80 connected!"
-            return 1
-          elif [[ "$count" -gt 1 ]]; then
-            # Multiple matches. Print them and exit
-            echo "Error: $count Glove80s connected. Expected 1!"
-            for i in "''${!matches[@]}"; do
-              kb="''${matches[$i]}"
-              # Print the relevant lines from INFO_UF2
-              echo "$((i + 1)). $kb"
-              grep --no-filename --color=never Glove80 "$kb"/INFO_UF2.TXT | indent
-            done
-            return 1
-          fi
 
-          # We have a winner!
-          kb="''${matches[0]}"
-          echo "Flashing keyboard:"
-          echo "$kb"
-          indent < "$kb"/INFO_UF2.TXT
+          # Print a summary of what `list_keyboards` has found
+          echo "Found $count keyboards connected."
+          for i in "''${!matches[@]}"; do
+            kb="''${matches[$i]}"
+            # Print the relevant lines from INFO_UF2
+            echo "$((i + 1)). $kb"
+            indent < "$kb"/INFO_UF2.TXT
+          done
+          echo # blankline
+
+          for i in "''${!matches[@]}"; do
+            flash_keyboard "$((i + 1))" "''${matches[$i]}"
+          done
+        }
+
+        # Flash the given keyboard
+        flash_keyboard() {
+          i="$1"
+          kb="$2"
 
           # Ask before flashing...
-          if gum confirm "Are you sure?" \
+          if gum confirm "$i. $kb" \
               --default="yes" \
               --affirmative="Flash" \
               --negative="Cancel"
           then
             # Flash by copying the firmware package
-            gum spin --title "Flashing firmware..." \
+            gum spin --title "Flashing $kb" \
               -- cp -Tfr "${config.packages.firmware}" "$kb" \
-              && echo "Firmaware flashed!" \
-              || echo "Error flashing firmware!"
+              && echo "$i. Flashed $kb" \
+              || echo "$i. Error flashing $kb!"
           else
-            echo "Cancelled"
+            echo "$i. Skipped $kb"
           fi
-
-          echo # blankline
         }
 
         # Run the script
-        flash
+        flash_keyboards
         while
-          gum confirm \
+          gum confirm "Done" \
             --default="no" \
             --affirmative="Run again" \
-            --negative="Quit" \
-            "Flash another keyboard?"
+            --negative="Quit"
         do
           echo # blankline
           echo "Running again"
-          flash
+          flash_keyboards
         done
       '';
     };

--- a/packages/flash.nix
+++ b/packages/flash.nix
@@ -29,70 +29,90 @@
           sed -e 's/^/    /'
         }
 
-        # Platform specific disk candidates
-        declare -a disks
-        if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-          # Linux/GNU
-          # - /run/media/<user>/<disk>
-          disks=(/run/media/"$(whoami)"/GLV80*)
-        elif [[ "$OSTYPE" == "darwin"* ]]; then
-          # Mac OSX
-          # - /Volumes/<disk>
-          disks=(/Volumes/GLV80*)
-        elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
-          # Cygwin or Msys2
-          # - /<drive letter>
-          disks=(/?)
-        elif (grep -sq Microsoft /proc/version); then
-          # WSL
-          # - /mnt/<drive letter>
-          disks=(/mnt/?)
-        else
-          echo "Error: Unable to detect platform!"
-          echo "OSTYPE=$OSTYPE"
-          echo "/proc/version"
-          indent < /proc/version
-          exit 1
-        fi
-
-        # Disks that have a matching INFO_UF2
-        declare -a matches
-        for disk in "''${disks[@]}"; do
-          if (grep -sq Glove80 "$disk"/INFO_UF2.TXT); then
-            matches+=("$disk")
+        # Prints a list of connected glove80s
+        list_keyboards() {
+          # Platform specific disk candidates
+          declare -a disks
+          if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+            # Linux/GNU
+            # - /run/media/<user>/<disk>
+            disks=(/run/media/"$(whoami)"/GLV80*)
+          elif [[ "$OSTYPE" == "darwin"* ]]; then
+            # Mac OSX
+            # - /Volumes/<disk>
+            disks=(/Volumes/GLV80*)
+          elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+            # Cygwin or Msys2
+            # - /<drive letter>
+            disks=(/?)
+          elif grep -sq Microsoft /proc/version; then
+            # WSL
+            # - /mnt/<drive letter>
+            disks=(/mnt/?)
+          else
+            echo "Error: Unable to detect platform!" >&2
+            echo "OSTYPE=$OSTYPE" >&2
+            echo "/proc/version" >&2
+            indent < /proc/version >&2
           fi
-        done
 
-        # Assert we found exactly one keyboard
-        count="''${#matches[@]}"
-        if [[ "$count" -lt 1 ]]; then
-          # No matches. Exit
-          echo "Error: No Glove80 connected!"
-          exit 1
-        elif [[ "$count" -gt 1 ]]; then
-          # Multiple matches. Print them and exit
-          echo "Error: $count Glove80s connected. Expected 1!"
-          for i in "''${!matches[@]}"; do
-            kb="''${matches[$i]}"
-            # Print the relevant lines from INFO_UF2
-            echo "$((i + 1)). $kb"
-            grep --no-filename --color=never Glove80 "$kb"/INFO_UF2.TXT | indent
+          # Print disks that have a matching INFO_UF2
+          for disk in "''${disks[@]}"; do
+            if (grep -sq Glove80 "$disk"/INFO_UF2.TXT); then
+              echo "$disk"
+            fi
           done
-          exit 1
-        fi
+        }
 
-        # We have a winner!
-        kb="''${matches[0]}"
-        echo "Found keyboard:"
-        echo "$kb"
-        indent < "$kb"/INFO_UF2.TXT
-        echo
+        flash() {
+          declare -a matches
+          readarray -t matches < <(list_keyboards)
 
-        # Flash by copying the firmware package
-        gum spin --title "Flashing firmware..." \
-          -- cp -Tfr "${config.packages.firmware}" "$kb" \
-          && echo "Firmaware flashed!" \
-          || echo "Error flashing firmware!"
+          # Assert we found exactly one keyboard
+          count="''${#matches[@]}"
+          if [[ "$count" -lt 1 ]]; then
+            # No matches. Exit
+            echo "Error: No Glove80 connected!"
+            return 1
+          elif [[ "$count" -gt 1 ]]; then
+            # Multiple matches. Print them and exit
+            echo "Error: $count Glove80s connected. Expected 1!"
+            for i in "''${!matches[@]}"; do
+              kb="''${matches[$i]}"
+              # Print the relevant lines from INFO_UF2
+              echo "$((i + 1)). $kb"
+              grep --no-filename --color=never Glove80 "$kb"/INFO_UF2.TXT | indent
+            done
+            return 1
+          fi
+
+          # We have a winner!
+          kb="''${matches[0]}"
+          echo "Found keyboard:"
+          echo "$kb"
+          indent < "$kb"/INFO_UF2.TXT
+          echo
+
+          # Flash by copying the firmware package
+          gum spin --title "Flashing firmware..." \
+            -- cp -Tfr "${config.packages.firmware}" "$kb" \
+            && echo "Firmaware flashed!" \
+            || echo "Error flashing firmware!"
+        }
+
+        # Run the script
+        flash
+        while
+          gum confirm \
+            --default="no" \
+            --affirmative="Run again" \
+            --negative="Quit" \
+            "Flash another keyboard?"
+        do
+          echo # blankline
+          echo "Running again"
+          flash
+        done
       '';
     };
   };

--- a/packages/flash.nix
+++ b/packages/flash.nix
@@ -8,6 +8,10 @@
     # Builds the firmware and copies it to the plugged-in keyboard half
     packages.flash = pkgs.writeShellApplication {
       name = "flash";
+      runtimeInputs = [
+        # Use Charm Gum for fancy interactivity
+        pkgs.gum
+      ];
       text = ''
         set +e
 
@@ -16,6 +20,9 @@
 
         # Enable nullglob so that non-matching globs have no output
         shopt -s nullglob
+
+        # Style
+        export GUM_SPIN_SPINNER="minidot"
 
         # Indent piped input 4 spaces
         indent() {
@@ -82,9 +89,10 @@
         echo
 
         # Flash by copying the firmware package
-        echo "Flashing firmware..."
-        cp -r "${config.packages.firmware}" "$kb" \
-          && echo "Done!" || echo "Error: Unable to flash firmware!"
+        gum spin --title "Flashing firmware..." \
+          -- cp -Tfr "${config.packages.firmware}" "$kb" \
+          && echo "Firmaware flashed!" \
+          || echo "Error flashing firmware!"
       '';
     };
   };

--- a/packages/flash.nix
+++ b/packages/flash.nix
@@ -36,7 +36,9 @@
           if [[ "$OSTYPE" == "linux-gnu"* ]]; then
             # Linux/GNU
             # - /run/media/<user>/<disk>
-            disks=(/run/media/"$(whoami)"/GLV80*)
+            disks+=(/run/media/"$(whoami)"/GLV80*)
+            disks+=(/media/GLV80*)
+            disks+=(/mnt/*)
           elif [[ "$OSTYPE" == "darwin"* ]]; then
             # Mac OSX
             # - /Volumes/<disk>


### PR DESCRIPTION
- **feat(flash): show a spinner while flashing**
- **feat(flash): Ask to run again**
- **feat(flash): Ask before flashing**
- **feat(flash): Allow flashing multiple keyboards**
- **feat(flash): Support more linux mount points**
- **feat(flash): Allow passing keyboards via CLI args**

TODO
- [ ] Use `gum choose` to select keyboards, instead of prompting one at a time

Fixes #12
