### PR TITLE
Test NixOS/nixpkgs#450602

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,28 @@
         "type": "github"
       }
     },
+    "nixpkgs-pr": {
+      "locked": {
+        "lastModified": 1760541192,
+        "narHash": "sha256-wAZKxLTvGIOzO+FOVpaJCdWX+YQzA+gIIunczHLPDbQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "56d4cd679b0f1159d01f5d9b866ebdd23869bb9f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "pull/450602/merge",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "glove80-zmk": "glove80-zmk",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-pr": "nixpkgs-pr"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs-pr.url = "github:nixos/nixpkgs?ref=pull/450602/merge";
     glove80-zmk = {
       url = "github:moergo-sc/zmk";
       flake = false;

--- a/packages/flake-module.nix
+++ b/packages/flake-module.nix
@@ -20,7 +20,7 @@ let
 in
 {
   perSystem =
-    { pkgs, ... }:
+    { pkgs, inputs', ... }:
     {
       packages = lib.pipe ./. [
         readDir
@@ -29,6 +29,11 @@ in
         (filterAttrs (name: pkg: hasSuffix ".nix" (toString pkg)))
         (filterAttrs (name: lib.pathIsRegularFile))
         (mapAttrs' (name: pkg: lib.nameValuePair (removeSuffix ".nix" name) (pkgs.callPackage pkg { })))
+        (packages: packages // {
+          draw = packages.draw.override {
+            keymap-drawer = inputs'.nixpkgs-pr.legacyPackages.keymap-drawer;
+          };
+        })
       ];
     };
 }


### PR DESCRIPTION
- Adds a secondary nixpkgs input, targeting NixOS/nixpkgs#450602
- Override `keymap-drawer` input to the `draw` package.
- Tested locally that `nix run .#draw` produces no errors and no diff.
